### PR TITLE
TASK-54576: Keep displaying the already created requests from a deactivated process in 'my requests' tab

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/storage/ProcessesStorageImpl.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/storage/ProcessesStorageImpl.java
@@ -134,7 +134,7 @@ public class ProcessesStorageImpl implements ProcessesStorage {
 
   @Override
   public List<Work> getWorks(long userIdentityId, int offset, int limit) throws Exception {
-    List<WorkFlow> workFlows = findEnabledWorkFlows(0, 0);
+    List<WorkFlow> workFlows = findAllWorkFlows(0, 0);
     List<Long> projectsIds = workFlows.stream().map(WorkFlow::getProjectId).collect(Collectors.toList());
     TaskQuery taskQuery = new TaskQuery();
     taskQuery.setProjectIds(projectsIds);


### PR DESCRIPTION

Keep displaying the already created requests from a deactivated process in 'my requests' tab by getting all created requests of the current user from all workflows (activtaed and deactivted processes)