### PR TITLE
TASK-56705: Filtering processes by query on slow internet connection shows duplicated result

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
@@ -45,7 +45,7 @@
           <v-text-field
             v-if="!isXSmall"
             class="me-4 workflow-filter-query filter-query-width float-e"
-            @keyup="updateFilter"
+            @keyup="filterByQuery"
             v-model="query"
             :placeholder="$t('processes.workflow.filter.query.placeholder')"
             prepend-inner-icon="mdi-filter" />
@@ -57,7 +57,7 @@
           cols="12">
           <v-text-field
             class="me-10 workflow-filter-query float-e"
-            @keyup="updateFilter"
+            @keyup="filterByQuery"
             v-model="query"
             :placeholder="$t('processes.workflow.filter.query.placeholder')"
             prepend-inner-icon="mdi-filter" />
@@ -125,6 +125,8 @@ export default {
         {label: this.$t('processes.workflow.all.label'), value: null},
       ],
       query: null,
+      searchTimer: null,
+      endTypingKeywordTimeout: 200,
     };
   },
   props: {
@@ -193,6 +195,16 @@ export default {
     },
     loadMore() {
       this.$root.$emit('load-more-workflows');
+    },
+    filterByQuery() {
+      clearTimeout(this.searchTimer);
+      this.searchTimer = setTimeout(() => {
+        if (this.loading) {
+          this.filterByQuery();
+          return;
+        }
+        this.updateFilter();
+      }, this.endTypingKeywordTimeout);
     },
     updateFilter() {
       this.$root.$emit('workflow-filter-changed', {filter: this.filter.value, query: this.query});


### PR DESCRIPTION
Prior to this change, When searching processes by query with a slow net connection the http calls are submitted without waiting the user to end writing which doesn't give the vue page a chance to get updated
in the right time because the render of the page will be late so the results are added without clearing the already filled search result.
This PR will add a wait timeout for the user typing and then will submit the get call