### PR TITLE
TASK-57250: Fix request not canceled

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -54,8 +54,7 @@
       :message="confirmMessage"
       :ok-label="$t('processes.workflow.ok.label')"
       :cancel-label="$t('processes.workflow.cancel.label')"
-      @ok="confirmAction"
-      @dialog-closed="onDialogClosed" />
+      @ok="confirmAction"/>
     <add-workflow-drawer
       ref="addWorkFlow" />
     <add-work-drawer
@@ -437,6 +436,7 @@ export default {
       if (this.dialogAction && this.dialogAction === 'cancel_work') {
         this.updateWorkCompleted(this.targetModel, true, true);
       }
+      this.onDialogClosed();
     },
     deleteWorkDraftById(workDraft) {
       return this.$processesService.deleteWorkDraftById(workDraft.id).then(value => {


### PR DESCRIPTION
ISSUES : when we cancel a request added for a process ,request not canceled.
FIX : The problem is that the dialog-closed event is thrown before the request is cancelled, which makes this.dialogAction null,fixed by adding the close of dialog after the confirm of action.