### PR TITLE
Task-57403: Add missing sequence to fix PostgreSQL error

### DIFF
--- a/processes-services/src/main/resources/db/changelog/processes-rdbms.db.changelog-1.0.0.xml
+++ b/processes-services/src/main/resources/db/changelog/processes-rdbms.db.changelog-1.0.0.xml
@@ -97,4 +97,7 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.-->
             <column name="ILLUSTRATION_IMAGE_ID" type="BIGINT" defaultValueNumeric="0" />
         </addColumn>
     </changeSet>
+    <changeSet author="processes" id="1.0.0-5" dbms="hsqldb,oracle,postgresql">
+        <createSequence sequenceName="SEQ_WORK_ID" startValue="1"/>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
ISSUE: With PostgreSQL SGBD we cannot make a process request and an error is occurred : "seq_work_id" does not exist. This is due to the SequenceGenerator which is not functional in the WorkEntity for postgreSQL database.
FIX : Add missing sequence "SEQ_WORK_ID" in the changelog. 