### PR TITLE
TASK-56754: display a process title on multiple lines

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
@@ -52,7 +52,7 @@
       </v-list>
     </v-menu>
     <v-card-title
-      class="text-center d-block mt-0 text-truncate workflow-title-card">
+      class="text-center d-block mt-0">
       <v-avatar
         v-if="avatarUrl"
         size="40px">


### PR DESCRIPTION
ISSUE: process titles gets truncated and is displayed with ellipses on small screens
FIX: removed the text-truncated CSS class to disable the truncating for title and removed the workflow-title-card CSS class so that the title doesn't overflow over the description