### PR TITLE
TASK-56754: fixed the card's title height and increased the card height

### DIFF
--- a/processes-webapp/src/main/webapp/skin/less/processes.less
+++ b/processes-webapp/src/main/webapp/skin/less/processes.less
@@ -332,6 +332,9 @@
   .custom-counter {
     height: 20px
   }
+  .card-title {
+    height: 67px
+  }
 }
 
 .processes-work-menu-icon {

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
@@ -1,6 +1,6 @@
 <template>
   <v-card
-    min-height="317px"
+    min-height="350px"
     class="mt-2 mb-2 me-3"
     outlined>
     <v-btn
@@ -52,7 +52,7 @@
       </v-list>
     </v-menu>
     <v-card-title
-      class="text-center d-block mt-0">
+      class="text-center d-block mt-0 card-title">
       <v-avatar
         v-if="avatarUrl"
         size="40px">


### PR DESCRIPTION
ISSUE: in a process card the divider overlay the "make a request" button, this happens because the height for the title section is not fixed and due to the resent changes where we displayed the entirety of the title, the height for this section can vary and if the title uses all 50 characters the divider will get pushed down and it will overlay the button.

FIX:fixed the height for the title section and increased the card height to accommodate the new height increase for the title 