### PR TITLE
TASK-56754: adjust the card title and content height

### DIFF
--- a/processes-webapp/src/main/webapp/skin/less/processes.less
+++ b/processes-webapp/src/main/webapp/skin/less/processes.less
@@ -113,7 +113,7 @@
   }
 
   .card-content {
-    height: 144px
+    height: 125px
   }
 
   .workflow-card-desc {
@@ -333,7 +333,7 @@
     height: 20px
   }
   .card-title {
-    height: 67px
+    height: 90px
   }
 }
 


### PR DESCRIPTION
ISSUE: the card description overlays the title when the screen is small
FIX: adjust the the height for the title and content of the drawer