### PR TITLE
TASK-58286: add workflow to the list if the filter is set to all

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
@@ -156,7 +156,7 @@ export default {
   },
   created() {
     this.$root.$on('workflow-added', (event) => {
-      if (event.workflow.enabled === event.filter) {
+      if (event.filter == null || event.workflow.enabled === event.filter) {
         this.workflowList.unshift(event.workflow);
       }
     });


### PR DESCRIPTION
ISSUE: when we set the filter to "All/Tous" and we add a new process, this process doesn't get displayed in the list
FIX: add the process to the list if the filter is set to "All/Tous"