### PR TITLE
TASK-56754: adjust the card title and content height

### DIFF
--- a/processes-webapp/src/main/webapp/skin/less/processes.less
+++ b/processes-webapp/src/main/webapp/skin/less/processes.less
@@ -113,9 +113,11 @@
   }
 
   .card-content {
-    height: 144px
+    height: 137px
   }
-
+  .card-title {
+    height: 90px
+  }
   .workflow-card-desc {
     min-height: 88px;
   }


### PR DESCRIPTION
ISSUE: the card description overlays the title when the screen is small
FIX: adjust the the height for the title and content of the drawer