### PR TITLE
TASK-58131: hide the filter in requests tab if there are no requests

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/MyWorkList.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/MyWorkList.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     id="myWorks">
-    <v-container class="pa-0 work-controls">
+    <v-container class="pa-0 work-controls" v-show="showWorkFilter">
       <v-row no-gutters>
         <v-col
           height="150">
@@ -139,6 +139,9 @@ export default {
       default: () => {
         return {};
       }
+    },
+    showWorkFilter: {
+      type: Boolean,
     }
   },
   created() {


### PR DESCRIPTION
ISSUE: if there are no requests or drafts the filter stays visible
FIX: show the filter if a request has been made (once a request is created it can not be deleted, so the filter needs to stay visible) or the list of drafts is not empty.
drafts can be deleted by the user, and in the scenario where there are no requests only drafts we need to make sure that the filter appears and disappear when appropriate.