### PR TITLE
TASK-58131: hide the filter in requests tab if there are no requests

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/MyWorkList.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/MyWorkList.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     id="myWorks">
-    <v-container class="pa-0 work-controls">
+    <v-container class="pa-0 work-controls" v-show="showWorkFilter">
       <v-row no-gutters>
         <v-col
           height="150">
@@ -139,6 +139,9 @@ export default {
       default: () => {
         return {};
       }
+    },
+    showWorkFilter: {
+      type: Boolean,
     }
   },
   created() {

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -35,7 +35,8 @@
             :works="works"
             :work-drafts="workDrafts"
             :completed-works="completedWorks"
-            :loading="loading" />
+            :loading="loading"
+            :show-work-filter="requestSubmited || allWorkDrafts.length" />
         </v-tab-item>
       </v-tabs-items>
     </v-card>
@@ -79,6 +80,7 @@ export default {
       workflows: [],
       works: [],
       workDrafts: [],
+      allWorkDrafts: [],
       completedWorks: [],
       query: null,
       enabled: true,
@@ -95,6 +97,7 @@ export default {
       targetModel: null,
       myRequestsTabVisited: null,
       showProcessFilter: false,
+      requestSubmited: false,      
     };
   },
   beforeCreate() {
@@ -208,6 +211,9 @@ export default {
         }
       }));
     }, 300);
+    this.$processesService.getWorks(null,0,0,'workFlow').then(list =>{
+      this.requestSubmited = list.length > 0;
+    });
   },
   computed: {
     isMobile() {
@@ -361,15 +367,19 @@ export default {
       });
     },
     getWorkDrafts() {
-      const filter = {};
-      if (this.query) {
-        filter.query = this.query;
-      }
       const expand = '';
       this.limit = this.limit || this.pageSize;
       this.loading = true;
-      return this.$processesService.getWorkDrafts(filter, 0, 0, expand).then(drafts => {
-        this.workDrafts = drafts || [];
+      return this.$processesService.getWorkDrafts(null, 0, 0, expand).then(drafts => {
+        this.allWorkDrafts = drafts || [];
+        if (this.query){
+          this.workDrafts = this.allWorkDrafts.filter(elem=>{
+            return elem.description && elem.description.replace(/\s/g,'').replace(/<\/?[^>]+(>|$)/gi, '').includes(this.query.replace(/\s/g,''));
+          });
+        }
+        else {
+          this.workDrafts = this.allWorkDrafts;
+        }
       }).finally(() => this.loading = false);
     },
     displayMessage(alert) {
@@ -399,6 +409,7 @@ export default {
             this.workDrafts.splice(this.workDrafts.indexOf(work.draftId), 1);
           }
           this.displayMessage({type: 'success', message: this.$t('processes.work.add.success.message')});
+          this.requestSubmited = true;
         }
       }).catch(() => {
         this.displayMessage({type: 'error', message: this.$t('processes.work.add.error.message')});


### PR DESCRIPTION
ISSUE: if there are no requests or drafts the filter stays visible
FIX: show the filter if a request has been made (once a request is created it can not be deleted, so the filter needs to stay visible) or the list of drafts is not empty.
drafts can be deleted by the user, and in the scenario where there are no requests only drafts we need to make sure that the filter appears and disappear when appropriate.