### PR TITLE
TASK-58163: fix illustrative image disappear after editing a process

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
@@ -312,7 +312,7 @@ export default {
            || null,
           fileName: image.name,
           fileBody: e.target.result
-                 && e.target.result !== 'data:'
+                 && e.target.result.length >23
                  && e.target.result || null,
           mimeType: image.type,
           fileSize: image.size,


### PR DESCRIPTION
ISSUE: when we edit a process or the firefox browser, it's illustrative image disappear.
FIX: This is due the workflow.illustrativeAttachment.fileBody not being set to null on firefox.
when we have an already uploaded image the e.target.result is evaluated to "data:" on chrome and "data:image/(format); base64," on firefox.
if we update a process without changing the image, the fileBody property need to be set to null
this is why we need to take both cases of the e.target.result property into account