### PR TITLE
TASK-58604: fix space avatar image not being displayed

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowSuggesterSpace.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowSuggesterSpace.vue
@@ -33,7 +33,7 @@ export default {
           providerId: 'space',
           spaceId: space.id,
           profile: {
-            avatarUrl: space.avatar,
+            avatarUrl: space.avatarUrl,
             fullName: space.displayName,
           }
         };


### PR DESCRIPTION
ISSUE: after creating a process and adding a space where this process belongs to the avatar image of the space doesn't get displayed when we edit the process
FIX: assign the avatarUrl property the appropriate value