### PR TITLE
TASK:58043: remove duplicate metrics tracking the access to the process application

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -209,7 +209,6 @@ export default {
           userId: eXo.env.portal.userIdentityId,
           userName: eXo.env.portal.userName,
           operation: 'accessProcessesApp',
-          name: 'access to processes application',
           timestamp: Date.now()
         }
       }));


### PR DESCRIPTION
ISSUE: there are two metrics tracking the access to the process application, 'UI interaction' with value 'access to processes application' and 'operation' with value 'Processes app access'.
FIX: removed the setting of the 'UI interaction' property to 'access to processes application' when opening the process application