### PR TITLE
TASK-58829: enable continue button even if the space doesnt have the task application

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
@@ -208,7 +208,7 @@
               <v-btn
                 class="btn btn-primary me-4"
                 outlined
-                :disabled="!workflowChanged || !validSpace"
+                :disabled="!workflowChanged"
                 @click="nextStep">
                 {{ $t('processes.works.form.label.continue') }}
                 <v-icon size="18" class="ms-2">


### PR DESCRIPTION
ISSUE: current behavior is that when creating a process and the user selects a space, in the second step, that doesn't have the task application a warning is displayed and the continue button is disabled
FIX: the continue button stays enabled 