### PR TITLE
Update poi library from 4.1.2 to 5.2.2 - EXO-59736

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/storage/ProcessesStorageImpl.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/storage/ProcessesStorageImpl.java
@@ -8,7 +8,6 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang.StringUtils;
-import org.apache.xmlbeans.impl.util.Base64;
 
 import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.file.model.FileInfo;
@@ -246,7 +245,7 @@ public class ProcessesStorageImpl implements ProcessesStorage {
     FileItem fileItem;
     try {
       String data = illustrativeAttachment.getFileBody().split("base64,")[1];
-      byte[] bytes = Base64.decode(data.getBytes(Charset.defaultCharset().name()));
+      byte[] bytes = Base64.getDecoder().decode(data.getBytes(Charset.defaultCharset().name()));
       fileItem = new FileItem(illustrativeAttachment.getId(),
                               illustrativeAttachment.getFileName(),
                               illustrativeAttachment.getMimeType(),


### PR DESCRIPTION
Before this change, a high vulnerability is observed in poi-scratchpad:4.1.2 library This fix update poi-scratchpad to the last available version 5.2.2 To follow this library update, this fix also update commons-io from 2.7 to 2.11.0 and xmlbeans from 3.1.0 to 5.0.3