### PR TITLE
fix: The selected groups as process request creators are not displayed when we edit a process -EXO-59927 

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/Utils/EntityMapper.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/Utils/EntityMapper.java
@@ -76,7 +76,7 @@ public class EntityMapper {
         identityEntities.add(new CreatorIdentityEntity(identityEntity));
       } else {
         try {
-          Group group = groupHandler.findGroupById(manager);
+          Group group = manager.contains("/platform/") ? groupHandler.findGroupById(manager) : groupHandler.findGroupById("/platform/" + manager);
           ProfileEntity profile = new ProfileEntity(null, group.getLabel());
           IdentityEntity identityEntity = new IdentityEntity("group:" + group.getGroupName(), group.getId(), "group", profile);
           identityEntities.add(new CreatorIdentityEntity(identityEntity));

--- a/processes-services/src/test/java/org/exoplatform/processes/Utils/EntityMapperTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/Utils/EntityMapperTest.java
@@ -1,0 +1,67 @@
+package org.exoplatform.processes.Utils;
+
+import org.exoplatform.commons.utils.CommonsUtils;
+import org.exoplatform.processes.entity.WorkFlowEntity;
+import org.exoplatform.processes.model.WorkFlow;
+import org.exoplatform.services.organization.Group;
+import org.exoplatform.services.organization.GroupHandler;
+import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.social.core.space.spi.SpaceService;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+import java.util.*;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+@RunWith(PowerMockRunner.class)
+public class EntityMapperTest {
+    @Mock
+    private OrganizationService        organizationService;
+    @Mock
+    private SpaceService               spaceService;
+    @Mock
+    private Group group;
+    @Mock
+    private GroupHandler groupHandler;
+
+    @Test
+    @PrepareForTest({ CommonsUtils.class })
+    public void fromEntity() throws Exception {
+        PowerMockito.mockStatic(CommonsUtils.class);
+        when(CommonsUtils.getService(OrganizationService.class)).thenReturn(organizationService);
+        when(CommonsUtils.getService(SpaceService.class)).thenReturn(spaceService);
+        when(spaceService.getSpaceByGroupId("manager")).thenReturn(null);
+        when(spaceService.getSpaceByGroupId("/platform/manager")).thenReturn(null);
+        when(organizationService.getGroupHandler()).thenReturn(groupHandler);
+        when(groupHandler.findGroupById("manager")).thenReturn(group);
+        when(groupHandler.findGroupById("/platform/manager")).thenReturn(group);
+        when(groupHandler.findGroupById("exception")).thenReturn(null);
+        when(group.getGroupName()).thenReturn("manager");
+        when(group.getId()).thenReturn("manager");
+        when(group.getLabel()).thenReturn("managers");
+        WorkFlowEntity workFlowEntity = new WorkFlowEntity();
+        workFlowEntity.setId(1L);
+        workFlowEntity.setTitle("workFlow");
+        workFlowEntity.setCreatorId(1L);
+        workFlowEntity.setSummary("workFlow summary");
+        workFlowEntity.setModifierId(1L);
+        workFlowEntity.setTitle("workFlow");
+        workFlowEntity.setEnabled(true);
+        workFlowEntity.setDescription("test");
+        workFlowEntity.setProjectId(1L);
+        workFlowEntity.hashCode();
+        workFlowEntity.equals(workFlowEntity);
+        workFlowEntity.toString();
+        List<String> memberships = new ArrayList<>();
+        memberships.add("manager");
+        memberships.add("/platform/manager");
+        Set<String> managers = new HashSet<>(Arrays.asList(memberships.get(0),memberships.get(1)));
+        workFlowEntity.setManager(managers);
+        WorkFlow newWorkFlow = EntityMapper.fromEntity(workFlowEntity,memberships);
+        assertEquals(newWorkFlow.getManager().size(),managers.size());
+    }
+}

--- a/processes-services/src/test/java/org/exoplatform/processes/Utils/EntityMapperTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/Utils/EntityMapperTest.java
@@ -6,10 +6,12 @@ import org.exoplatform.processes.model.WorkFlow;
 import org.exoplatform.services.organization.Group;
 import org.exoplatform.services.organization.GroupHandler;
 import org.exoplatform.services.organization.OrganizationService;
+import org.exoplatform.social.core.space.model.Space;
 import org.exoplatform.social.core.space.spi.SpaceService;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
@@ -19,49 +21,56 @@ import static org.mockito.Mockito.when;
 
 @RunWith(PowerMockRunner.class)
 public class EntityMapperTest {
-    @Mock
-    private OrganizationService        organizationService;
-    @Mock
-    private SpaceService               spaceService;
-    @Mock
-    private Group group;
-    @Mock
-    private GroupHandler groupHandler;
+  @Mock
+  private OrganizationService organizationService;
 
-    @Test
-    @PrepareForTest({ CommonsUtils.class })
-    public void fromEntity() throws Exception {
-        PowerMockito.mockStatic(CommonsUtils.class);
-        when(CommonsUtils.getService(OrganizationService.class)).thenReturn(organizationService);
-        when(CommonsUtils.getService(SpaceService.class)).thenReturn(spaceService);
-        when(spaceService.getSpaceByGroupId("manager")).thenReturn(null);
-        when(spaceService.getSpaceByGroupId("/platform/manager")).thenReturn(null);
-        when(organizationService.getGroupHandler()).thenReturn(groupHandler);
-        when(groupHandler.findGroupById("manager")).thenReturn(group);
-        when(groupHandler.findGroupById("/platform/manager")).thenReturn(group);
-        when(groupHandler.findGroupById("exception")).thenReturn(null);
-        when(group.getGroupName()).thenReturn("manager");
-        when(group.getId()).thenReturn("manager");
-        when(group.getLabel()).thenReturn("managers");
-        WorkFlowEntity workFlowEntity = new WorkFlowEntity();
-        workFlowEntity.setId(1L);
-        workFlowEntity.setTitle("workFlow");
-        workFlowEntity.setCreatorId(1L);
-        workFlowEntity.setSummary("workFlow summary");
-        workFlowEntity.setModifierId(1L);
-        workFlowEntity.setTitle("workFlow");
-        workFlowEntity.setEnabled(true);
-        workFlowEntity.setDescription("test");
-        workFlowEntity.setProjectId(1L);
-        workFlowEntity.hashCode();
-        workFlowEntity.equals(workFlowEntity);
-        workFlowEntity.toString();
-        List<String> memberships = new ArrayList<>();
-        memberships.add("manager");
-        memberships.add("/platform/manager");
-        Set<String> managers = new HashSet<>(Arrays.asList(memberships.get(0),memberships.get(1)));
-        workFlowEntity.setManager(managers);
-        WorkFlow newWorkFlow = EntityMapper.fromEntity(workFlowEntity,memberships);
-        assertEquals(newWorkFlow.getManager().size(),managers.size());
-    }
+  @Mock
+  private SpaceService        spaceService;
+  
+  @Mock
+  private Space               testSpace;
+
+  @Mock
+  private Group               contributorsGroup;
+  
+  @Mock
+  private Group               administratorsGroup;
+
+  @Mock
+  private GroupHandler        groupHandler;
+
+  @Test
+  @PrepareForTest({ CommonsUtils.class })
+  public void fromEntity() throws Exception {
+    PowerMockito.mockStatic(CommonsUtils.class);
+    when(CommonsUtils.getService(OrganizationService.class)).thenReturn(organizationService);
+    when(CommonsUtils.getService(SpaceService.class)).thenReturn(spaceService);
+    when(spaceService.getSpaceByGroupId("web-contributors")).thenReturn(null);
+    when(spaceService.getSpaceByGroupId("/platform/administrators")).thenReturn(null);
+    Space testSpace = Mockito.mock(Space.class);
+    when(spaceService.getSpaceByGroupId("/spaces/testSpace")).thenReturn(testSpace);
+    when(organizationService.getGroupHandler()).thenReturn(groupHandler);
+    when(groupHandler.findGroupById("web-contributors")).thenReturn(null);
+    Group contributorsGroup = Mockito.mock(Group.class);
+    when(groupHandler.findGroupById("/platform/web-contributors")).thenReturn(contributorsGroup);
+    Group administratorsGroup = Mockito.mock(Group.class);
+    when(groupHandler.findGroupById("/platform/administrators")).thenReturn(administratorsGroup);
+    WorkFlowEntity workFlowEntity = new WorkFlowEntity();
+    workFlowEntity.setId(1L);
+    workFlowEntity.setTitle("workFlow");
+    workFlowEntity.setCreatorId(1L);
+    workFlowEntity.setSummary("workFlow summary");
+    workFlowEntity.setModifierId(1L);
+    workFlowEntity.setTitle("workFlow");
+    workFlowEntity.setEnabled(true);
+    workFlowEntity.setDescription("test");
+    workFlowEntity.setProjectId(1L);
+    Set<String> managers = new HashSet<String>();
+    managers.add("web-contributors");
+    managers.add("/platform/administrators");
+    managers.add("/spaces/testSpace");
+    workFlowEntity.setManager(managers);
+    WorkFlow workFlow = EntityMapper.fromEntity(workFlowEntity, null);
+    assertEquals(workFlow.getManager().size(), managers.size());
+  }
 }

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowSuggesterRequest.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowSuggesterRequest.vue
@@ -86,12 +86,17 @@ export default {
       }
 
       const found = this.workflowRequest.find(attendee => {
-        return attendee.identity.remoteId === this.invitedAttendee.remoteId
+        return (attendee.identity.remoteId === this.invitedAttendee.remoteId
+            || attendee.identity.remoteId === this.invitedAttendee.spaceId)
             && attendee.identity.providerId === this.invitedAttendee.providerId;
       });
       if (!found) {
+        const suggesterItemToIdentity = this.$suggesterService.convertSuggesterItemToIdentity(this.invitedAttendee);
+        if (this.invitedAttendee && this.invitedAttendee.providerId === 'group'){
+          suggesterItemToIdentity.remoteId = this.invitedAttendee.spaceId ;
+        }
         this.workflowRequest.push({
-          identity: this.$suggesterService.convertSuggesterItemToIdentity(this.invitedAttendee),
+          identity: suggesterItemToIdentity,
         });
       }
       this.invitedAttendee = null;


### PR DESCRIPTION
Prior to this change, when we edit a process having groups as process request creators, in step 3 these groups are not displayed in the suggester. It is due to storing groupName instead of groupId which causes an exception when getting the group using groupHandler.findGroupById(manager).
After this change, we ensure to store the whole groupId which allows to get correclty the group and display it in the suggester like for spaces. 