### PR TITLE
fix: Adjust work description tooltip styles - EXO-61327

### DIFF
--- a/processes-webapp/src/main/webapp/skin/less/processes.less
+++ b/processes-webapp/src/main/webapp/skin/less/processes.less
@@ -526,3 +526,11 @@
 .card-edit-text-size {
   font-size: 13px;
 }
+
+.work-description-tooltip {
+  max-width: 388px;
+
+  p:last-child {
+    margin-bottom: 0 !important;
+  }
+}

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkBody.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkBody.vue
@@ -138,7 +138,9 @@
                 {{ workDescription }}
               </span>
             </template>
-            <span v-sanitized-html="workObject.description"></span>
+            <p
+              class="work-description-tooltip mb-0 text-break"
+              v-sanitized-html="workObject.description"></p>
           </v-tooltip>
         </v-col>
         <v-col

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/mobile/WorkBodyMobile.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/mobile/WorkBodyMobile.vue
@@ -98,7 +98,9 @@
                       {{ workDescription }}
                     </div>
                   </template>
-                  <span v-sanitized-html="workObject.description"></span>
+                  <p
+                    class="work-description-tooltip mb-0 text-break"
+                    v-sanitized-html="workObject.description"></p>
                 </v-tooltip>
               </div>
             </v-col>


### PR DESCRIPTION
Prior to this change, the work description tooltip was displaying a html content which makes its depends on vuetify-all defined styles for html nodes such as p, which takes always margin-bttom 10px even if it was a last child which makes it visible in such type of diplay with popovers and colored background. This PR adds a custom margin style to last child of P node to fix the display issue