### PR TITLE
 fix:retrieve correctly the renamed space - EXO-61820 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ build
 npm-debug.log
 node_modules
 /bin/
+
+# vscode
+.vscode/

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowSuggesterSpace.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowSuggesterSpace.vue
@@ -72,20 +72,16 @@ export default {
   watch: {
     workFlowOwner() {
       this.resetCustomValidity();
-      if (this.workFlowOwner) {
-        this.workflow.parentSpace = {
-          id: this.workFlowOwner.spaceId,
-          displayName: this.workFlowOwner.profile.fullName,
-          groupId: `/spaces/${this.workFlowOwner.remoteId}`,
-          name: this.workFlowOwner.remoteId,
-          prettyName: this.workFlowOwner.remoteId,
-          url: this.workFlowOwner.remoteId,
-          avatarUrl: this.workFlowOwner.profile.avatar,
-        };
+      if (this.workFlowOwner && this.workFlowOwner.spaceId) {
+        this.$spaceService.getSpaceById(this.workFlowOwner.spaceId)
+          .then(space => {
+            this.workflow.parentSpace = space;
+            this.$emit('initialized');
+          });
       } else {
         this.workflow.parentSpace = null;
+        this.$emit('initialized');
       }
-      this.$emit('initialized');
     },
   },
   methods: {

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
@@ -131,23 +131,22 @@ export default {
     attachmentsLength() {
       return this.attachments && this.attachments.length > 0 ? `(${this.attachments.length})` : '';
     },
-    drive() {
-      if (this.workflowParentSpace) {
-        const spaceGroupId = this.workflowParentSpace.groupId.split('/spaces/')[1];
-        return {
-          name: `.spaces.${spaceGroupId}`,
-          title: this.workflowParentSpace.prettyName,
-          isSelected: true
-        };
-      }
-      return null;
-    },
     isMobileDevice() {
       return (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
     }
   },
   created() {
     this.initEntityAttachmentsList();
+    if (this.workflowParentSpace) {
+      this.$spaceService.getSpaceByPrettyName(this.workflowParentSpace.prettyName)
+        .then(space => {
+          this.drive = {
+            name: `${space.groupId.replaceAll('/', '.')}`,
+            title: space.displayName,
+            isSelected: true
+          };
+        });
+    }
     document.addEventListener('attachment-added', event => {
       if (this.editMode) {
         this.initEntityAttachmentsList();


### PR DESCRIPTION
Prior to this fix, we could not attach files nor create forms for a process that is managed by a renamed space because the group Id of the space was calculated based on the remoteId which changes when the space is renamed.
This fix retrieves correctly the space by calling Space Rest API instead of calculating the group of the space based on its remoteId