### PR TITLE
fix:retrieve correctly the renamed space - EXO-61820 (#253)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,6 @@ build
 npm-debug.log
 node_modules
 /bin/
+
+# vscode
+.vscode/

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowSuggesterSpace.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowSuggesterSpace.vue
@@ -1,0 +1,118 @@
+<!--
+Copyright (C) 2022 eXo Platform SAS.
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU Affero General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Affero General Public License for more details.
+You should have received a copy of the GNU Affero General Public License
+along with this program. If not, see <http://www.gnu.org/licenses/>.
+-->
+<template>
+  <exo-identity-suggester
+    ref="workFlowOwnerSuggester"
+    v-model="workFlowOwner"
+    :labels="workFlowSuggesterLabels"
+    :include-users="false"
+    :search-options="searchOptions"
+    :width="220"
+    name="workFlowOwnerAutocomplete"
+    class="user-suggester workFlowOwnerAutocomplete"
+    include-spaces
+    required />
+</template>
+
+<script>
+export default {
+  props: {
+    workflow: {
+      type: Object,
+      default: () => null,
+    },
+  },
+  data() {
+    return {
+      workFlowOwner: null,
+    };
+  },
+  created(){
+    this.$root.$on('set-workflow-space', (space) => {
+      if (space){
+        this.workFlowOwner = {
+          remoteId: space.prettyName,
+          providerId: 'space',
+          spaceId: space.id,
+          profile: {
+            avatarUrl: space.avatarUrl,
+            fullName: space.displayName,
+          }
+        };
+      } else {
+        this.workFlowOwner = {};
+      }
+    });
+  },
+  computed: {
+    workFlowSuggesterLabels() {
+      return {
+        searchPlaceholder: this.$t('processes.works.form.request.chooseSpacer'),
+        placeholder: this.$t('processes.works.form.searchPlaceholder'),
+        noDataLabel: this.$t('processes.works.form.noDataLabel'),
+      };
+    },
+    searchOptions() {
+      return {
+        filterType: 'all',
+      };
+    },
+  },
+  watch: {
+    workFlowOwner() {
+      this.resetCustomValidity();
+      if (this.workFlowOwner && this.workFlowOwner.spaceId) {
+        this.$spaceService.getSpaceById(this.workFlowOwner.spaceId)
+          .then(space => {
+            this.workflow.parentSpace = space;
+            this.$emit('initialized');
+          });
+      } else {
+        this.workflow.parentSpace = null;
+        this.$emit('initialized');
+      }
+    },
+  },
+  methods: {
+    resetCustomValidity() {
+      if (this.$refs.workFlowOwnerSuggester) {
+        this.$refs.workFlowOwnerSuggester.$el.querySelector('input').setCustomValidity('');
+      }
+    },
+    reset() {
+      if (this.workflow.id ||  (this.workflow && this.workflow.space && (this.workflow.space.id || (this.workflow.space.remoteId && this.workflow.space.providerId)))) { // In case of edit existing event
+        this.workFlowOwner = this.$suggesterService.convertIdentityToSuggesterItem(this.workflow.space);
+
+        window.setTimeout(() => {
+          if (this.$refs.workFlowOwnerSuggester) {
+            this.$refs.workFlowOwnerSuggester.items = [this.workFlowOwner];
+          }
+          this.$emit('initialized');
+        }, 200);
+      } else {
+        if (this.$refs.workFlowOwnerSuggester) {
+          this.$refs.workFlowOwnerSuggester.items = [this.workFlowOwner];
+        } else {
+          if (this.$refs.workFlowOwnerSuggester) {
+            this.$refs.workFlowOwnerSuggester.items = [];
+          }
+          this.workFlowOwner = {};
+        }
+        this.$emit('initialized');
+      }
+      this.$forceUpdate();
+    },
+  }
+};
+</script>

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
@@ -108,9 +108,6 @@ export default {
     attachmentsLength() {
       return this.attachments && this.attachments.length > 0 ? `(${this.attachments.length})` : '';
     },
-    isMobileDevice() {
-      return (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
-    }
   },
   created() {
     this.initEntityAttachmentsList();

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
@@ -108,20 +108,22 @@ export default {
     attachmentsLength() {
       return this.attachments && this.attachments.length > 0 ? `(${this.attachments.length})` : '';
     },
-    drive() {
-      if (this.workflowParentSpace) {
-        const spaceGroupId = this.workflowParentSpace.groupId.split('/spaces/')[1];
-        return {
-          name: `.spaces.${spaceGroupId}`,
-          title: this.workflowParentSpace.prettyName,
-          isSelected: true
-        };
-      }
-      return null;
+    isMobileDevice() {
+      return (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
     }
   },
   created() {
     this.initEntityAttachmentsList();
+    if (this.workflowParentSpace) {
+      this.$spaceService.getSpaceByPrettyName(this.workflowParentSpace.prettyName)
+        .then(space => {
+          this.drive = {
+            name: `${space.groupId.replaceAll('/', '.')}`,
+            title: space.displayName,
+            isSelected: true
+          };
+        });
+    }
     document.addEventListener('attachment-added', event => {
       if (this.editMode) {
         this.initEntityAttachmentsList();


### PR DESCRIPTION
Prior to this fix, we could not attach files nor create forms for a process that is managed by a renamed space because the group Id of the space was calculated based on the remoteId which changes when the space is renamed. This fix retrieves correctly the space by calling Space Rest API instead of calculating the group of the space based on its remoteId

(cherry picked from commit c06b8bb23459a24e436c79b8216b10705375e48d)