### PR TITLE
fix: members of space managing a process should receive notifications for processes creation/cancellation/commenting - EXO-62246  (#259)

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/listener/CancelRequestNotificationListener.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/listener/CancelRequestNotificationListener.java
@@ -20,6 +20,7 @@ public class CancelRequestNotificationListener extends Listener<TaskDto, Project
     ctx.append(NotificationArguments.REQUEST_CREATOR, taskDto.getCreatedBy());
     ctx.append(NotificationArguments.PROCESS_URL, NotificationUtils.getProcessLink(projectDto.getId()));
     ctx.append(NotificationArguments.REQUEST_URL, NotificationUtils.getRequestLink(taskDto.getId()));
+    ctx.append(NotificationArguments.WORKFLOW_PROJECT_ID, String.valueOf(projectDto.getId()));
     ctx.getNotificationExecutor()
             .with(ctx.makeCommand(PluginKey.key(CancelRequestPlugin.ID))).execute(ctx);
   }

--- a/processes-services/src/main/java/org/exoplatform/processes/listener/CreateRequestNotificationListener.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/listener/CreateRequestNotificationListener.java
@@ -23,6 +23,7 @@ public class CreateRequestNotificationListener extends Listener<Work, ProjectDto
     ctx.append(NotificationArguments.REQUEST_DESCRIPTION, work.getDescription());
     ctx.append(NotificationArguments.PROCESS_URL, NotificationUtils.getProcessLink(projectDto.getId()));
     ctx.append(NotificationArguments.REQUEST_URL, NotificationUtils.getRequestLink(work.getId()));
+    ctx.append(NotificationArguments.WORKFLOW_PROJECT_ID, String.valueOf(work.getProjectId()));
     ctx.getNotificationExecutor()
             .with(ctx.makeCommand(PluginKey.key(CreateRequestPlugin.ID))).execute(ctx);
   }

--- a/processes-services/src/main/java/org/exoplatform/processes/listener/RequestCommentNotificationListener.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/listener/RequestCommentNotificationListener.java
@@ -55,7 +55,8 @@ public class RequestCommentNotificationListener extends TaskCommentNotificationL
     ctx.append(NotificationArguments.REQUEST_COMMENT_AUTHOR, comment.getAuthor());
     ctx.append(NotificationArguments.REQUEST_COMMENT, comment.getComment());
     ctx.append(NotificationArguments.PROCESS_URL, NotificationUtils.getProcessLink(project.getId()));
-    ctx.append(NotificationArguments.REQUEST_COMMENT_URL, NotificationUtils.getRequestCommentsLink(task.getId()));
+    ctx.append(NotificationArguments.REQUEST_COMMENT_URL, NotificationUtils.getRequestLink(task.getId()));
+    ctx.append(NotificationArguments.WORKFLOW_PROJECT_ID, String.valueOf(project.getId()));
     ctx.getNotificationExecutor()
             .with(ctx.makeCommand(PluginKey.key(RequestCommentPlugin.ID))).execute(ctx);
   }

--- a/processes-services/src/main/java/org/exoplatform/processes/notification/plugin/CancelRequestPlugin.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/notification/plugin/CancelRequestPlugin.java
@@ -9,6 +9,8 @@ import org.exoplatform.processes.notification.utils.NotificationUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
 
+import java.util.List;
+
 public class CancelRequestPlugin extends BaseNotificationPlugin {
   private static final Log   LOG = ExoLogger.getLogger(CancelRequestPlugin.class);
 
@@ -33,9 +35,11 @@ public class CancelRequestPlugin extends BaseNotificationPlugin {
     String requester = notificationContext.value(NotificationArguments.REQUEST_CREATOR);
     String processUrl = notificationContext.value(NotificationArguments.PROCESS_URL);
     String requestUrl = notificationContext.value(NotificationArguments.REQUEST_URL);
+    String workflowProjectId = notificationContext.value(NotificationArguments.WORKFLOW_PROJECT_ID);
+    List<String> receivers = NotificationUtils.getReceivers(Long.parseLong(workflowProjectId), requester, true);
     return NotificationInfo.instance()
                            .setFrom(requester)
-                           .to(NotificationUtils.getProcessAdmins(requester))
+                           .to(receivers)
                            .with(NotificationArguments.REQUEST_CREATOR.getKey(), requester)
                            .with(NotificationArguments.PROCESS_URL.getKey(), processUrl)
                            .with(NotificationArguments.REQUEST_URL.getKey(), requestUrl)

--- a/processes-services/src/main/java/org/exoplatform/processes/notification/plugin/CreateRequestPlugin.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/notification/plugin/CreateRequestPlugin.java
@@ -1,7 +1,6 @@
 package org.exoplatform.processes.notification.plugin;
 
 import org.exoplatform.commons.api.notification.NotificationContext;
-import org.exoplatform.commons.api.notification.model.ArgumentLiteral;
 import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
 import org.exoplatform.container.xml.InitParams;
@@ -9,6 +8,8 @@ import org.exoplatform.processes.notification.utils.NotificationArguments;
 import org.exoplatform.processes.notification.utils.NotificationUtils;
 import org.exoplatform.services.log.ExoLogger;
 import org.exoplatform.services.log.Log;
+
+import java.util.List;
 
 public class CreateRequestPlugin extends BaseNotificationPlugin {
 
@@ -38,9 +39,11 @@ public class CreateRequestPlugin extends BaseNotificationPlugin {
     String requestTitle = notificationContext.value(NotificationArguments.REQUEST_TITLE);
     String requestDescription = notificationContext.value(NotificationArguments.REQUEST_DESCRIPTION);
     String requestUrl = notificationContext.value(NotificationArguments.REQUEST_URL);
+    String workflowProjectId = notificationContext.value(NotificationArguments.WORKFLOW_PROJECT_ID);
+    List<String> receivers = NotificationUtils.getReceivers(Long.parseLong(workflowProjectId), requester, true);
     return NotificationInfo.instance()
                            .setFrom(requester)
-                           .to(NotificationUtils.getProcessAdmins(requester))
+                           .to(receivers)
                            .with(NotificationArguments.REQUEST_CREATOR.getKey(), requester)
                            .with(NotificationArguments.REQUEST_PROCESS.getKey(), process)
                            .with(NotificationArguments.REQUEST_TITLE.getKey(), requestTitle)

--- a/processes-services/src/main/java/org/exoplatform/processes/notification/plugin/RequestCommentPlugin.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/notification/plugin/RequestCommentPlugin.java
@@ -21,6 +21,9 @@ import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.processes.notification.utils.NotificationArguments;
+import org.exoplatform.processes.notification.utils.NotificationUtils;
+
+import java.util.List;
 
 public class RequestCommentPlugin extends BaseNotificationPlugin {
 
@@ -37,8 +40,7 @@ public class RequestCommentPlugin extends BaseNotificationPlugin {
 
   @Override
   public boolean isValid(NotificationContext notificationContext) {
-    return !notificationContext.value(NotificationArguments.REQUEST_COMMENT_AUTHOR)
-                               .equals(notificationContext.value(NotificationArguments.REQUEST_CREATOR));
+    return true ;
   }
 
   @Override
@@ -50,9 +52,14 @@ public class RequestCommentPlugin extends BaseNotificationPlugin {
     String commentAuthor = notificationContext.value(NotificationArguments.REQUEST_COMMENT_AUTHOR);
     String comment = notificationContext.value(NotificationArguments.REQUEST_COMMENT);
     String requestCommentUrl = notificationContext.value(NotificationArguments.REQUEST_COMMENT_URL);
+    String workflowProjectId = notificationContext.value(NotificationArguments.WORKFLOW_PROJECT_ID);
+    List<String> receivers = NotificationUtils.getReceivers(Long.parseLong(workflowProjectId), commentAuthor, false);
+    if (!receivers.contains(requester) && !requester.equals(commentAuthor)) {
+      receivers.add(requester);
+    }
     return NotificationInfo.instance()
                            .setFrom(commentAuthor)
-                           .to(requester)
+                           .to(receivers)
                            .with(NotificationArguments.REQUEST_CREATOR.getKey(), requester)
                            .with(NotificationArguments.REQUEST_PROCESS.getKey(), processTitle)
                            .with(NotificationArguments.REQUEST_TITLE.getKey(), requestTitle)

--- a/processes-services/src/main/java/org/exoplatform/processes/notification/utils/NotificationArguments.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/notification/utils/NotificationArguments.java
@@ -22,4 +22,6 @@ public class NotificationArguments {
 
   public static final ArgumentLiteral<String> REQUEST_COMMENT_URL    = new ArgumentLiteral<>(String.class, "REQUEST_COMMENT_URL");
 
+  public static final ArgumentLiteral<String> WORKFLOW_PROJECT_ID    = new ArgumentLiteral<>(String.class, "WORKFLOW_PROJECT_ID");
+
 }

--- a/processes-services/src/test/java/org/exoplatform/processes/notification/plugin/CancelRequestPluginTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/notification/plugin/CancelRequestPluginTest.java
@@ -8,6 +8,7 @@ import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.processes.notification.utils.NotificationArguments;
 import org.exoplatform.processes.notification.utils.NotificationUtils;
+import org.exoplatform.processes.service.ProcessesService;
 import org.exoplatform.services.idgenerator.IDGeneratorService;
 import org.junit.Before;
 import org.junit.Test;
@@ -18,8 +19,7 @@ import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
-import java.util.ArrayList;
-import java.util.List;
+import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -33,6 +33,9 @@ public class CancelRequestPluginTest {
   @Mock
   private InitParams          initParams;
 
+  @Mock
+  private ProcessesService processesService;
+
   private CancelRequestPlugin cancelRequestPlugin;
 
   @Before
@@ -42,17 +45,19 @@ public class CancelRequestPluginTest {
     PowerMockito.mockStatic(NotificationUtils.class);
     PowerMockito.mockStatic(ExoContainerContext.class);
     when(ExoContainerContext.getService(IDGeneratorService.class)).thenReturn(null);
+    when(CommonsUtils.getService(ProcessesService.class)).thenReturn(processesService);
   }
 
   @Test
   public void makeNotification() {
     NotificationContext ctx = NotificationContextImpl.cloneInstance();
     ctx.append(NotificationArguments.REQUEST_CREATOR, "root");
+    ctx.append(NotificationArguments.WORKFLOW_PROJECT_ID, "1");
     List<String> receivers = new ArrayList<>();
     receivers.add("user1");
-    receivers.add("user1");
+    receivers.add("user2");
     ctx.append(NotificationArguments.PROCESS_URL, "http://exoplatfrom.com/dw/tasks/projectDetail/1");
-    when(NotificationUtils.getProcessAdmins("root")).thenReturn(receivers);
+    when(NotificationUtils.getReceivers(1l , "root", true)).thenReturn(receivers);
     NotificationInfo notificationInfo = cancelRequestPlugin.makeNotification(ctx);
     assertEquals("root", notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_CREATOR.getKey()));
     assertEquals("http://exoplatfrom.com/dw/tasks/projectDetail/1",

--- a/processes-services/src/test/java/org/exoplatform/processes/notification/plugin/CreateRequestPluginTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/notification/plugin/CreateRequestPluginTest.java
@@ -7,8 +7,10 @@ import org.exoplatform.commons.notification.impl.NotificationContextImpl;
 import org.exoplatform.commons.utils.CommonsUtils;
 import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
+import org.exoplatform.processes.model.WorkFlow;
 import org.exoplatform.processes.notification.utils.NotificationArguments;
 import org.exoplatform.processes.notification.utils.NotificationUtils;
+import org.exoplatform.processes.service.ProcessesService;
 import org.exoplatform.services.idgenerator.IDGeneratorService;
 import org.junit.Before;
 import org.junit.Test;
@@ -20,7 +22,9 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import static org.junit.Assert.*;
 import static org.powermock.api.mockito.PowerMockito.when;
@@ -33,6 +37,9 @@ public class CreateRequestPluginTest {
   @Mock
   private InitParams          initParams;
 
+  @Mock
+  private ProcessesService processesService;
+
   private CreateRequestPlugin createRequestPlugin;
 
   @Before
@@ -42,6 +49,7 @@ public class CreateRequestPluginTest {
     PowerMockito.mockStatic(NotificationUtils.class);
     PowerMockito.mockStatic(ExoContainerContext.class);
     when(ExoContainerContext.getService(IDGeneratorService.class)).thenReturn(null);
+    when(CommonsUtils.getService(ProcessesService.class)).thenReturn(processesService);
   }
 
   @Test
@@ -53,10 +61,11 @@ public class CreateRequestPluginTest {
     ctx.append(NotificationArguments.REQUEST_DESCRIPTION, "test description");
     ctx.append(NotificationArguments.PROCESS_URL, "http://exoplatfrom.com/dw/tasks/projectDetail/1");
     ctx.append(NotificationArguments.REQUEST_URL, "http://exoplatfrom.com/dw/tasks/taskDetail/1");
+    ctx.append(NotificationArguments.WORKFLOW_PROJECT_ID, "1");
     List<String> receivers = new ArrayList<>();
     receivers.add("user1");
-    receivers.add("user1");
-    when(NotificationUtils.getProcessAdmins("root")).thenReturn(receivers);
+    receivers.add("user2");
+    when(NotificationUtils.getReceivers(1l , "root", true)).thenReturn(receivers);
     NotificationInfo notificationInfo = createRequestPlugin.makeNotification(ctx);
     assertEquals("root", notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_CREATOR.getKey()));
     assertEquals("http://exoplatfrom.com/dw/tasks/projectDetail/1",

--- a/processes-services/src/test/java/org/exoplatform/processes/notification/plugin/RequestCommentPluginTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/notification/plugin/RequestCommentPluginTest.java
@@ -10,6 +10,7 @@ import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.processes.notification.utils.NotificationArguments;
 import org.exoplatform.processes.notification.utils.NotificationUtils;
+import org.exoplatform.processes.service.ProcessesService;
 import org.exoplatform.services.idgenerator.IDGeneratorService;
 import org.junit.Before;
 import org.junit.Test;
@@ -23,7 +24,6 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.ArrayList;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
@@ -34,6 +34,9 @@ public class RequestCommentPluginTest extends TestCase {
     @Mock
     private InitParams initParams;
 
+    @Mock
+    private ProcessesService processesService;
+
     private RequestCommentPlugin requestCommentPlugin;
 
     @Before
@@ -43,20 +46,7 @@ public class RequestCommentPluginTest extends TestCase {
         PowerMockito.mockStatic(NotificationUtils.class);
         PowerMockito.mockStatic(ExoContainerContext.class);
         when(ExoContainerContext.getService(IDGeneratorService.class)).thenReturn(null);
-    }
-
-    @Test
-    public void isValid() {
-        NotificationContext ctx1 = NotificationContextImpl.cloneInstance();
-        ctx1.append(NotificationArguments.REQUEST_CREATOR, "root");
-        ctx1.append(NotificationArguments.REQUEST_COMMENT_AUTHOR, "user");
-        boolean valid = requestCommentPlugin.isValid(ctx1);
-        assertTrue(valid);
-        NotificationContext ctx2 = NotificationContextImpl.cloneInstance();
-        ctx2.append(NotificationArguments.REQUEST_CREATOR, "root");
-        ctx2.append(NotificationArguments.REQUEST_COMMENT_AUTHOR, "root");
-        valid = requestCommentPlugin.isValid(ctx2);
-        assertFalse(valid);
+        when(CommonsUtils.getService(ProcessesService.class)).thenReturn(processesService);
     }
 
     @Test
@@ -69,9 +59,14 @@ public class RequestCommentPluginTest extends TestCase {
         ctx.append(NotificationArguments.REQUEST_COMMENT, "test");
         ctx.append(NotificationArguments.PROCESS_URL, "http://exoplatfrom.com/dw/tasks/projectDetail/1");
         ctx.append(NotificationArguments.REQUEST_COMMENT_URL, "http://exoplatfrom.com/dw/processes/myRequests/requestDetails/1/comments");
+        ctx.append(NotificationArguments.WORKFLOW_PROJECT_ID, "1");
 
         List<String> receivers = new ArrayList<>();
+        receivers.add("user1");
+        receivers.add("user2");
         receivers.add("root");
+        when(NotificationUtils.getReceivers(1l , "user", false)).thenReturn(receivers);
+
         NotificationInfo notificationInfo = requestCommentPlugin.makeNotification(ctx);
         assertEquals("root", notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_CREATOR.getKey()));
         assertEquals("http://exoplatfrom.com/dw/tasks/projectDetail/1",


### PR DESCRIPTION
prior to this change, only the process administrator or request creator receives notification for creation/cancellation/comment on a process. After this change, Members of the space managing the process receives also notification for creation/cancellation/comment on a process