### PR TITLE
fix: Request comment - notifs sent to all in/out members - EXO-62688 (#264)

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/listener/RequestCommentNotificationListener.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/listener/RequestCommentNotificationListener.java
@@ -55,8 +55,7 @@ public class RequestCommentNotificationListener extends TaskCommentNotificationL
     ctx.append(NotificationArguments.REQUEST_COMMENT_AUTHOR, comment.getAuthor());
     ctx.append(NotificationArguments.REQUEST_COMMENT, comment.getComment());
     ctx.append(NotificationArguments.PROCESS_URL, NotificationUtils.getProcessLink(project.getId()));
-    ctx.append(NotificationArguments.REQUEST_COMMENT_URL, NotificationUtils.getRequestLink(task.getId()));
-    ctx.append(NotificationArguments.WORKFLOW_PROJECT_ID, String.valueOf(project.getId()));
+    ctx.append(NotificationArguments.REQUEST_COMMENT_URL, NotificationUtils.getRequestCommentsLink(task.getId()));
     ctx.getNotificationExecutor()
             .with(ctx.makeCommand(PluginKey.key(RequestCommentPlugin.ID))).execute(ctx);
   }

--- a/processes-services/src/main/java/org/exoplatform/processes/notification/plugin/RequestCommentPlugin.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/notification/plugin/RequestCommentPlugin.java
@@ -21,9 +21,6 @@ import org.exoplatform.commons.api.notification.model.NotificationInfo;
 import org.exoplatform.commons.api.notification.plugin.BaseNotificationPlugin;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.processes.notification.utils.NotificationArguments;
-import org.exoplatform.processes.notification.utils.NotificationUtils;
-
-import java.util.List;
 
 public class RequestCommentPlugin extends BaseNotificationPlugin {
 
@@ -40,7 +37,8 @@ public class RequestCommentPlugin extends BaseNotificationPlugin {
 
   @Override
   public boolean isValid(NotificationContext notificationContext) {
-    return true ;
+    return !notificationContext.value(NotificationArguments.REQUEST_COMMENT_AUTHOR)
+                               .equals(notificationContext.value(NotificationArguments.REQUEST_CREATOR));
   }
 
   @Override
@@ -52,14 +50,9 @@ public class RequestCommentPlugin extends BaseNotificationPlugin {
     String commentAuthor = notificationContext.value(NotificationArguments.REQUEST_COMMENT_AUTHOR);
     String comment = notificationContext.value(NotificationArguments.REQUEST_COMMENT);
     String requestCommentUrl = notificationContext.value(NotificationArguments.REQUEST_COMMENT_URL);
-    String workflowProjectId = notificationContext.value(NotificationArguments.WORKFLOW_PROJECT_ID);
-    List<String> receivers = NotificationUtils.getReceivers(Long.parseLong(workflowProjectId), commentAuthor, false);
-    if (!receivers.contains(requester) && !requester.equals(commentAuthor)) {
-      receivers.add(requester);
-    }
     return NotificationInfo.instance()
                            .setFrom(commentAuthor)
-                           .to(receivers)
+                           .to(requester)
                            .with(NotificationArguments.REQUEST_CREATOR.getKey(), requester)
                            .with(NotificationArguments.REQUEST_PROCESS.getKey(), processTitle)
                            .with(NotificationArguments.REQUEST_TITLE.getKey(), requestTitle)

--- a/processes-services/src/main/java/org/exoplatform/processes/notification/utils/NotificationUtils.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/notification/utils/NotificationUtils.java
@@ -114,15 +114,13 @@ public class NotificationUtils {
    * retrieves the members of spaces
    **/
 
-  public static List<String> getSpacesMembers(Set<String> spacesGroupsId) {
+  public static List<String> getSpacesMembers(String groupId) {
     List<String> members = new ArrayList<>();
     SpaceService spaceService = CommonsUtils.getService(SpaceService.class);
-    spacesGroupsId.forEach(groupId -> {
-      Space space = spaceService.getSpaceByGroupId(groupId);
-      if (space != null) {
-        members.addAll(Arrays.stream(space.getMembers()).collect(Collectors.toList()));
-      }
-    });
+    Space space = spaceService.getSpaceByGroupId(groupId);
+    if (space != null) {
+      members.addAll(Arrays.stream(space.getMembers()).collect(Collectors.toList()));
+    }
     return members;
   }
 
@@ -138,9 +136,11 @@ public class NotificationUtils {
     }
     WorkFlow workFlow = getWorkFlowByProjectId(workflowProjectId);
     if (workFlow != null) {
-      receivers.addAll(getSpacesMembers(workFlow.getManager()));
+      String spaceGroupId = workFlow.getParticipator().iterator().next().split(":")[1];
+      receivers.addAll(getSpacesMembers(spaceGroupId));
     }
+    receivers = receivers.stream().distinct().collect(Collectors.toList());
     receivers.remove(requester);
-    return receivers.stream().distinct().collect(Collectors.toList());
+    return receivers;
   }
 }

--- a/processes-services/src/test/java/org/exoplatform/processes/notification/plugin/RequestCommentPluginTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/notification/plugin/RequestCommentPluginTest.java
@@ -10,7 +10,6 @@ import org.exoplatform.container.ExoContainerContext;
 import org.exoplatform.container.xml.InitParams;
 import org.exoplatform.processes.notification.utils.NotificationArguments;
 import org.exoplatform.processes.notification.utils.NotificationUtils;
-import org.exoplatform.processes.service.ProcessesService;
 import org.exoplatform.services.idgenerator.IDGeneratorService;
 import org.junit.Before;
 import org.junit.Test;
@@ -24,6 +23,7 @@ import org.powermock.modules.junit4.PowerMockRunner;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.junit.Assert.assertEquals;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @RunWith(PowerMockRunner.class)
@@ -34,9 +34,6 @@ public class RequestCommentPluginTest extends TestCase {
     @Mock
     private InitParams initParams;
 
-    @Mock
-    private ProcessesService processesService;
-
     private RequestCommentPlugin requestCommentPlugin;
 
     @Before
@@ -46,36 +43,45 @@ public class RequestCommentPluginTest extends TestCase {
         PowerMockito.mockStatic(NotificationUtils.class);
         PowerMockito.mockStatic(ExoContainerContext.class);
         when(ExoContainerContext.getService(IDGeneratorService.class)).thenReturn(null);
-        when(CommonsUtils.getService(ProcessesService.class)).thenReturn(processesService);
+    }
+
+    @Test
+    public void isValid() {
+      NotificationContext ctx1 = NotificationContextImpl.cloneInstance();
+      ctx1.append(NotificationArguments.REQUEST_CREATOR, "root");
+      ctx1.append(NotificationArguments.REQUEST_COMMENT_AUTHOR, "user");
+      boolean valid = requestCommentPlugin.isValid(ctx1);
+      assertTrue(valid);
+      NotificationContext ctx2 = NotificationContextImpl.cloneInstance();
+      ctx2.append(NotificationArguments.REQUEST_CREATOR, "root");
+      ctx2.append(NotificationArguments.REQUEST_COMMENT_AUTHOR, "root");
+      valid = requestCommentPlugin.isValid(ctx2);
+      assertFalse(valid);
     }
 
     @Test
     public void testMakeNotification() {
-        NotificationContext ctx = NotificationContextImpl.cloneInstance();
-        ctx.append(NotificationArguments.REQUEST_CREATOR, "root");
-        ctx.append(NotificationArguments.REQUEST_TITLE, "test request");
-        ctx.append(NotificationArguments.REQUEST_PROCESS, "test process");
-        ctx.append(NotificationArguments.REQUEST_COMMENT_AUTHOR, "user");
-        ctx.append(NotificationArguments.REQUEST_COMMENT, "test");
-        ctx.append(NotificationArguments.PROCESS_URL, "http://exoplatfrom.com/dw/tasks/projectDetail/1");
-        ctx.append(NotificationArguments.REQUEST_COMMENT_URL, "http://exoplatfrom.com/dw/processes/myRequests/requestDetails/1/comments");
-        ctx.append(NotificationArguments.WORKFLOW_PROJECT_ID, "1");
+      NotificationContext ctx = NotificationContextImpl.cloneInstance();
+      ctx.append(NotificationArguments.REQUEST_CREATOR, "root");
+      ctx.append(NotificationArguments.REQUEST_TITLE, "test request");
+      ctx.append(NotificationArguments.REQUEST_PROCESS, "test process");
+      ctx.append(NotificationArguments.REQUEST_COMMENT_AUTHOR, "user");
+      ctx.append(NotificationArguments.REQUEST_COMMENT, "test");
+      ctx.append(NotificationArguments.PROCESS_URL, "http://exoplatfrom.com/dw/tasks/projectDetail/1");
+      ctx.append(NotificationArguments.REQUEST_COMMENT_URL,
+                 "http://exoplatfrom.com/dw/processes/myRequests/requestDetails/1/comments");
 
-        List<String> receivers = new ArrayList<>();
-        receivers.add("user1");
-        receivers.add("user2");
-        receivers.add("root");
-        when(NotificationUtils.getReceivers(1l , "user", false)).thenReturn(receivers);
-
-        NotificationInfo notificationInfo = requestCommentPlugin.makeNotification(ctx);
-        assertEquals("root", notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_CREATOR.getKey()));
-        assertEquals("http://exoplatfrom.com/dw/tasks/projectDetail/1",
-                notificationInfo.getValueOwnerParameter(NotificationArguments.PROCESS_URL.getKey()));
-        assertEquals("http://exoplatfrom.com/dw/processes/myRequests/requestDetails/1/comments",
-                notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_COMMENT_URL.getKey()));
-        assertEquals("test", notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_COMMENT.getKey()));
-        assertEquals("test request", notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_TITLE.getKey()));
-        assertEquals("user", notificationInfo.getFrom());
-        assertEquals(receivers, notificationInfo.getSendToUserIds());
+      List<String> receivers = new ArrayList<>();
+      receivers.add("root");
+      NotificationInfo notificationInfo = requestCommentPlugin.makeNotification(ctx);
+      assertEquals("root", notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_CREATOR.getKey()));
+      assertEquals("http://exoplatfrom.com/dw/tasks/projectDetail/1",
+                   notificationInfo.getValueOwnerParameter(NotificationArguments.PROCESS_URL.getKey()));
+      assertEquals("http://exoplatfrom.com/dw/processes/myRequests/requestDetails/1/comments",
+                   notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_COMMENT_URL.getKey()));
+      assertEquals("test", notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_COMMENT.getKey()));
+      assertEquals("test request", notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_TITLE.getKey()));
+      assertEquals("user", notificationInfo.getFrom());
+      assertEquals(receivers, notificationInfo.getSendToUserIds());
     }
 }


### PR DESCRIPTION
prior to this change, when someone comments on a process request all the space members received a notification after this change, only the requester receives the comment notification