### PR TITLE
fix: No bullet point display in work message to process manager - EXO-62697

### DIFF
--- a/processes-webapp/src/main/webapp/skin/less/processes.less
+++ b/processes-webapp/src/main/webapp/skin/less/processes.less
@@ -382,19 +382,16 @@
       min-height: 140px;
     }
 
-    .work-message {
-      &:extend(.work-description);
-      min-height: auto !important;
+    .work-description, .work-message {
+      ul li {
+        list-style-position: inside;
+        list-style-type: disc;
+      }
     }
 
     .work-description {
       min-height: 150px;
       word-break: break-word;
-
-      ul li {
-        list-style-position: inside;
-        list-style-type: disc;
-      }
 
       .uiIconMessageLength {
         font-size: 14px;
@@ -535,6 +532,11 @@
 
 .work-description-tooltip {
   max-width: 388px;
+
+  ul li {
+    list-style-position: inside;
+    list-style-type: disc;
+  }
 
   p:last-child {
     margin-bottom: 0 !important;


### PR DESCRIPTION
Prior to this change, no bullet points are displayed when they are added via cke in the work message.
 This PR should adjust the need styles to allow displaying the bullet points in the message