### PR TITLE
 fix: [Process] Saved values for (Who can make a request) - EXO-62861(#275)

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
@@ -531,6 +531,7 @@ export default {
       this.workflow = {};
       this.workflow.enabled = true;
       this.illustrativeInput = null;
+      this.workflowRequest = [];
     },
     addNewWorkFlow() {
       this.saving = true;


### PR DESCRIPTION
Prior to this change, when create a new process by filling all sections (Description of the process, Who can manage the process and Who can make a request) and create another process, when we reach the section (Who can make a request), we found that the values of the previous created process are filled.
 After this changes, All sections ( Who can make a request for this case) are empty when creating new process.

(cherry picked from commit 0b168993304118413bf6008edd507f9387e99e2f)