### PR TITLE
fix: display bottom menu for Safari - EXO-63021

### DIFF
--- a/processes-webapp/src/main/webapp/skin/less/processes.less
+++ b/processes-webapp/src/main/webapp/skin/less/processes.less
@@ -506,7 +506,7 @@
       transform: translateX(0%);
       width: 100% !important;
       bottom: 0 !important;
-      height: fit-content !important;
+      height: auto !important;
     }
   }
 


### PR DESCRIPTION
Using flex does ignore the effect of fit-content on Safari, we need to set the height to auto to make sure the filter menu is displayed on Mobile devices