### PR TITLE
fix: [Process]Issue with the values of the process quick filter EXO-62308

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/dao/WorkFlowDAO.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/dao/WorkFlowDAO.java
@@ -73,9 +73,11 @@ public class WorkFlowDAO extends GenericDAOJPAImpl<WorkFlowEntity, Long> {
         queryString = queryString + " AND";
       }
       if ( memberships != null){
-        queryString = queryString + " manager IN ('"+String.join("','", getMembersShipGroup(memberships))+"') ";
+        queryString = queryString + " ( manager IN ('"+String.join("','", getMembersShipGroup(memberships))+"') ";
         if ( Boolean.FALSE.equals(manager)){
-          queryString = queryString + " OR participator IN ('"+String.join("','", memberships)+"') ";
+          queryString = queryString + " OR participator IN ('"+String.join("','", memberships)+"')) ";
+        } else {
+          queryString = queryString + " AND participator IN ('"+String.join("','", memberships)+"')) ";
         }
       }
       if (queryString.endsWith(" AND")) {

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -156,7 +156,7 @@ export default {
     }).finally(() => {
       this.initializing = false;
       this.enabled = this.isManager ? null : true;
-      this.getWorkFlows();
+      this.getWorkFlows({ 'enabled': this.enabled});
     });
     this.$processesService.getAvailableWorkStatuses().then(statuses => {
       this.availableWorkStatuses = statuses;
@@ -428,12 +428,16 @@ export default {
         }
       });
     },
-    getWorkFlows() {
-      const filter = {};
+    getWorkFlows(filter) {
+      if (!filter) {
+        filter = {};
+      }
       if (this.query) {
         filter.query = this.query;
       }
-      filter.enabled = this.enabled;
+      if (!filter.enabled) {
+        filter.enabled = this.enabled;
+      }
       filter.manager = this.manager;
       const expand = '';
       this.limit = this.limit || this.pageSize;

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -156,7 +156,7 @@ export default {
     }).finally(() => {
       this.initializing = false;
       this.enabled = this.isManager ? null : true;
-      this.getWorkFlows({ 'enabled': this.enabled});
+      this.getWorkFlows({ 'enabled': true});
     });
     this.$processesService.getAvailableWorkStatuses().then(statuses => {
       this.availableWorkStatuses = statuses;

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
@@ -315,21 +315,13 @@ export default {
       this.$root.$emit('workflow-filter-changed', {filter: this.filter.value, query: this.query});
     },
     init(){
-      if (!this.isProcessesManager) {
-        const filter = {};
-        filter.enabled = true;
-        filter.manager = true;
-        this.$processesService.getWorkFlows(filter).then(workflows =>{
-          this.isMemberSpaceManager = workflows.length > 0;
-        });
-      }
-      this.filter = {label: this.$t('processes.workflow.all.label'), value: null};
-      this.filterItems.push({label: this.$t('processes.workflow.all.label'), value: null});
-      this.filterItems.push({label: this.$t('processes.workflow.manager.label'), value: 'manager' });
+      this.filter = this.isProcessesManager ? {label: this.$t('processes.workflow.activated.label'), value: 'activated'} : {label: this.$t('processes.workflow.all.label'), value: null};
       if (this.isProcessesManager) {
         this.filterItems.push({label: this.$t('processes.workflow.activated.label'), value: 'activated'});
         this.filterItems.push({label: this.$t('processes.workflow.deactivated.label'), value: 'deactivated'});
-      } 
+      }
+      this.filterItems.push({label: this.$t('processes.workflow.manager.label'), value: 'manager' });
+      this.filterItems.push({label: this.$t('processes.workflow.all.label'), value: null});
     }
   }
 };

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
@@ -315,6 +315,14 @@ export default {
       this.$root.$emit('workflow-filter-changed', {filter: this.filter.value, query: this.query});
     },
     init(){
+      if (!this.isProcessesManager) {
+        const filter = {};
+        filter.enabled = true;
+        filter.manager = true;
+        this.$processesService.getWorkFlows(filter).then(workflows =>{
+          this.isMemberSpaceManager = workflows.length > 0;
+        });
+      }
       this.filter = this.isProcessesManager ? {label: this.$t('processes.workflow.activated.label'), value: 'activated'} : {label: this.$t('processes.workflow.all.label'), value: null};
       if (this.isProcessesManager) {
         this.filterItems.push({label: this.$t('processes.workflow.activated.label'), value: 'activated'});

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
@@ -38,7 +38,7 @@
           sm="11"
           lg="6">
           <v-select
-            v-if="!isMobile"
+            v-if="!isMobile && (isMemberSpaceManager || isProcessesManager)"
             ref="filter"
             class="pt-5 workflow-filter mt-n3 float-e"
             v-model="filter"
@@ -198,6 +198,7 @@ export default {
       searchTimer: null,
       endTypingKeywordTimeout: 200,
       activatedFilters: [],
+      isMemberSpaceManager: false,
     };
   },
   props: {
@@ -314,13 +315,21 @@ export default {
       this.$root.$emit('workflow-filter-changed', {filter: this.filter.value, query: this.query});
     },
     init(){
-      this.filter = this.isProcessesManager ? {label: this.$t('processes.workflow.activated.label'), value: 'activated'} : {label: this.$t('processes.workflow.all.label'), value: null};
+      if (!this.isProcessesManager) {
+        const filter = {};
+        filter.enabled = true;
+        filter.manager = true;
+        this.$processesService.getWorkFlows(filter).then(workflows =>{
+          this.isMemberSpaceManager = workflows.length > 0;
+        });
+      }
+      this.filter = {label: this.$t('processes.workflow.all.label'), value: null};
+      this.filterItems.push({label: this.$t('processes.workflow.all.label'), value: null});
+      this.filterItems.push({label: this.$t('processes.workflow.manager.label'), value: 'manager' });
       if (this.isProcessesManager) {
         this.filterItems.push({label: this.$t('processes.workflow.activated.label'), value: 'activated'});
         this.filterItems.push({label: this.$t('processes.workflow.deactivated.label'), value: 'deactivated'});
-      }
-      this.filterItems.push({label: this.$t('processes.workflow.manager.label'), value: 'manager' });
-      this.filterItems.push({label: this.$t('processes.workflow.all.label'), value: null});
+      } 
     }
   }
 };


### PR DESCRIPTION
Prior to this change, when opened the process quick filter as it:

A process admin
-> the default is "On" and displays the exact same processes as the "All" value. In the requirement, I could find that it is the same definition. So it is useless to have both values.
 -> The "All" value does not display the deactivation process.
 

A process manager
  -> The default is "All" and I even see the deactivation process but I can’t query
  -> On the value I manage I only display the space I manage and which is enabled
 

A user
 -> The default is "All" and I see all the possible process for me and it’s enable.
 -> I have the value "I manage" even if I am not a process manager I should not see this value. So the quick filter is useless for a simple user.
 
To fix that, it is necessary to changée les labels de quick filter pour chaque type d'utilisateur dans la process et ajoutée a leur query.After this changes, when opened the process quick filter as it:

A process admin
-> Default value = Enabled = all processes enabled
-> I manage = all processes where I'm a member of the managing space
-> Deactivated = all processes deactivated
-> "All" = all enabled process + all disabled processes

A process manager
-> Default value = "All" = "All" = all enabled process
-> I manage = all processes where I'm a member of the managing space

A user
-> no quick filter