### PR TITLE
fix : Processes administrators' group member should not create any request if not allowed - EXO-62447

### DIFF
--- a/processes-services/src/test/java/org/exoplatform/processes/storage/ProcessesStorageImplTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/storage/ProcessesStorageImplTest.java
@@ -690,6 +690,18 @@ public class ProcessesStorageImplTest {
 
     when(organizationService.getMembershipHandler().findMembershipsByUser(identity.getRemoteId())).thenReturn(memberships_);
     assertEquals(1, this.processesStorage.findWorkFlows(filter, Long.parseLong(identity.getId()), 0, 0).size());
+
+    MembershipImpl adminProcesses = new MembershipImpl();
+    adminProcesses.setMembershipType("*");
+    adminProcesses.setUserName("user");
+    adminProcesses.setGroupId("/platform/processes");
+    memberships_.add(adminProcesses);
+
+    PROCESSES_UTILS.when(() -> ProcessesUtils.getProjectParentSpace(workFlow.getProjectId())).thenReturn(space);
+    ENTITY_MAPPER.when(() -> EntityMapper.fromEntity(newWorkFlowEntity1, null)).thenReturn(workFlow);
+
+    when(organizationService.getMembershipHandler().findMembershipsByUser(identity.getRemoteId())).thenReturn(memberships_);
+    assertEquals(0, this.processesStorage.findWorkFlows(filter, Long.parseLong(identity.getId()), 0, 0).size());
   }
 
   @Test


### PR DESCRIPTION
Prior to this change, when connected with a `Processes administrators` group member, It is possible to create a request of the process choose a Process for which I'm not in the list of `Who can make a request `. To fix that, when converting the `workFlowEntity` to `workFlow` you have to pass all the list of `memberShips` After this changes, a member of `Processes administrators` group should not be able to create a request if he is not allowed (member of the list `Who can make a request`)