### PR TITLE
fix: [PROCESSES] can't create a process : when thespace title's length is >= 35 - EXO-63689 (#301)

### DIFF
--- a/processes-services/src/main/resources/db/changelog/processes-rdbms.db.changelog-1.0.0.xml
+++ b/processes-services/src/main/resources/db/changelog/processes-rdbms.db.changelog-1.0.0.xml
@@ -130,4 +130,9 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.-->
         </modifySql>
     </changeSet>
 
+    <changeSet author="processes" id="1.0.0-8">
+        <modifyDataType tableName="WORK_FLOW_MANAGERS" columnName="MANAGER" newDataType="NVARCHAR(300)"/>
+        <modifyDataType tableName="WORK_FLOW_PARTICIPATOR" columnName="PARTICIPATOR" newDataType="NVARCHAR(300)"/>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
Prior to this change, when create space containing 35 chars or more, create a new process and in Who can manage the process type the created space fill the other fields then save, error creating the process. To solve this problem, increase the character number to 300 in the database type of two columns, one MANAGER in the WORK_FLOW_MANAGERS table and the other PARTICIPATOR in the WORK_FLOW_PARTICIPATOR table. After this modification, a process must be created thanks to the number of characters given to spaceGroupeId is 250 .

(cherry picked from commit c72dd75bfbea1eff2fc565b02d0dfe5a850d268e)