### PR TITLE
fix: [Process] Comment notif for a request and UX - EXO-62615

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -283,7 +283,13 @@ export default {
       }
     });
     document.addEventListener('Task-comments-drawer-closed', () => {
-      const url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/processes/myRequests`;
+      const urlInst = window.location.href;
+      if (urlInst.includes('comments')) {
+        const tab = urlInst.split('/');
+        const workId = tab[tab.length - 2];
+        this.openWorkDetails(workId);
+      }
+      const url = `${eXo.env.portal.context}/${eXo.env.portal.portalName}/processes/myRequests`;  
       window.history.pushState('myRequests', '', url);
     });
     this.$root.$on('processes-attachments-notification-alert', event => {


### PR DESCRIPTION
Prior to this change, when open the comment drawer of processes request according to a comment notification already received and click on the back arrow of the drawer, the drawer is closed and you don't know which request the comment was referring especially if you did several requests on the same day, each request has the same title in the notification. To fix this problem, retrieve the request id from the existing url and call the openWorkDetails method passing the retrieved id as a parameter to this method. After this change, When you click on the back arrow of the comment drawer, you have the drawer of the request opened and you can check about which request the comment is about.