### PR TITLE
fix: [PROCESS] mouse icons: if no action, do not display hand cursor - EXO-62606

### DIFF
--- a/processes-webapp/src/main/resources/locale/portlet/Processes_en.properties
+++ b/processes-webapp/src/main/resources/locale/portlet/Processes_en.properties
@@ -156,6 +156,7 @@ processes.work.unComplete.request.message=Unarchive
 processes.work.request.comment.message=Check comments
 processes.work.draft.delete.message=Delete your draft
 processes.work.draft.update.message=Update your draft
+processes.work.description.empty=Empty message
 processes.workflow.label.request=Request
 processes.workflow.label.pending=Pending
 

--- a/processes-webapp/src/main/webapp/skin/less/processes.less
+++ b/processes-webapp/src/main/webapp/skin/less/processes.less
@@ -4,6 +4,10 @@
 #ProcessesApplication {
 
   overflow-x: hidden;
+  
+  .cursor-default {
+    cursor: default;
+  }
 
   .no-pending-requests {
     color: @baseColorLight;

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkDrawer.vue
@@ -302,6 +302,12 @@ export default {
         this.viewMode = false;
         this.editDraft = true;
         this.firstCreation = false;
+        this.$root.$on('can-show-request-editor',() => {
+          this.showEditor = true;
+          window.setTimeout(() => {
+            this.$refs?.requestEditor?.setFocus();
+          }, 200);
+        });
       } else {
         this.viewDraft = isDraft || false;
         this.editDraft = false;

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/MyWorkList.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/MyWorkList.vue
@@ -14,6 +14,7 @@
             item-text="label"
             item-value="value"
             return-object
+            attach
             @blur="$refs.filter.blur();"
             @change="updateFilter"
             dense

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/RequestEditor.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/RequestEditor.vue
@@ -161,14 +161,14 @@ export default {
       }
     },
     setFocus: function() {
-      if (this.editorReady) {
-        window.setTimeout(() => {
+      window.setTimeout(() => {
+        if (this.editorReady) {
           const range = this.editor.createRange();
           range.moveToElementEditablePosition(range.root, true);
           this.editor.getSelection().selectRanges([range]);
           this.$nextTick().then(() => this.editor.focus());
-        }, 200);
-      }
+        }
+      }, 1000);
     },
     getMessage: function() {
       const newData = this.editor && this.editor.getData();

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkBody.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkBody.vue
@@ -70,7 +70,7 @@
           <div
             :class="!isDraft? 'ms-6':''"
             class="text-truncate"
-            @click="openRequest">
+            @click="openRequest(false)">
             <v-avatar
               v-if="workflowAvatarUrl"
               class="ms-2 me-n1"
@@ -133,9 +133,18 @@
             bottom>
             <template #activator="{ on, attrs }">
               <span
+                v-if="workDescription"
                 v-bind="attrs"
-                v-on="on">
+                v-on="on"
+                @click="openRequest(true)">
                 {{ workDescription }}
+              </span>
+              <span
+                v-else
+                class="grey--text"
+                v-bind="attrs"
+                @click="openRequest(true)">
+                {{ $t('processes.work.description.empty') }}
               </span>
             </template>
             <p
@@ -241,8 +250,11 @@ export default {
     updateCompleted() {
       this.$emit('update-work-completed');
     },
-    openRequest() {
+    openRequest(showEditor) {
       this.$emit('open-request');
+      if (showEditor) {
+        this.$root.$emit('can-show-request-editor');
+      }
     },
     openCommentsDrawer() {
       this.$emit('open-comments-drawer');

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/commons/RequestStatus.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/commons/RequestStatus.vue
@@ -11,7 +11,7 @@
           <span
             v-bind="attrs"
             v-on="on"
-            class="text-truncate ">
+            class="text-truncate cursor-default">
             {{ translatedLabel }}
           </span>
         </template>


### PR DESCRIPTION
Prior to this change, when display my requests , hover and click on description or status: hand mouse cursor displayed but nothing happens . To fix this problem, for the hover on status add a class css default-cursor to change the cursor to point to default because this field is not clickable and for the hover on description , this field is clickable so first of all we add an Empty message in this description field if it is empty and we add a can-shaow-request-editor event when we click on this field to open the addWorkDrawer drawer and focus the description field. After this change, when hover on the status field nothing changes and when we hover on the description field and click, the edit work drawer is opened and the cursor in the texteria of the description.