### PR TITLE
fix: Processes administrators group member should not create any request if not allowed - EXO-63860 (#313)

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -529,7 +529,8 @@ export default {
       this.saving = true;
       this.$processesService.addNewWorkFlow(workflow).then(workflow => {
         if (workflow){
-          this.$root.$emit('workflow-added', {workflow: workflow, filter: this.enabled});
+          this.getWorkFlows(workflow);
+          this.$root.$emit('workflow-added');
           this.displayMessage({type: 'success', message: this.$t('processes.workflow.add.success.message')});
           this.showProcessFilter = true;
         }

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
@@ -234,11 +234,6 @@ export default {
   },
   created() {
     this.init();
-    this.$root.$on('workflow-added', (event) => {
-      if (event.filter == null || event.workflow.enabled === event.filter) {
-        this.workflowList.unshift(event.workflow);
-      }
-    });
     this.$root.$on('workflow-updated', (workflow) => {
       workflow = JSON.parse(workflow);
       const index = this.workflowList.map(workflow => workflow.id).indexOf(workflow.id);

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowSuggesterSpace.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowSuggesterSpace.vue
@@ -64,9 +64,16 @@ export default {
       };
     },
     searchOptions() {
-      return {
-        filterType: 'all',
-      };
+      if (eXo.env.portal.isAdministrator) {
+        return {
+          filterType: 'all',
+        };
+      } else {
+        return {
+          filterType: 'member',
+        };
+      }
+      
     },
   },
   watch: {


### PR DESCRIPTION
Prior to this change, when connected with a Processes administrators group member, It is possible to create a request of the process choose a Process for which I'm not in the list of Who can make a request . After this changes, a member of Processes administrators group should not be able to create a request if he is not allowed (member of the list Who can make a request)

(cherry picked from commit 0cdc1641ad6bbe188bbe65680b763a0c15d1a65e)