### PR TITLE
fix:[Process] Mail notification contains HTML tags -EXO-64330

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/notification/provider/MailTemplateProvider.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/notification/provider/MailTemplateProvider.java
@@ -65,7 +65,7 @@ public class MailTemplateProvider extends TemplateProvider {
         String processTitle = notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_PROCESS.getKey());
         templateContext.put("PROCESS_TITLE", encoder.encode(processTitle));
         templateContext.put("REQUEST_TITLE", encoder.encode(requestTitle));
-        templateContext.put("REQUEST_DESCRIPTION", encoder.encode(requestDescription));
+        templateContext.put("REQUEST_DESCRIPTION", requestDescription);
       }
       templateContext.put("PROCESS_URL", encoder.encode(processUrl));
       templateContext.put("REQUEST_URL", encoder.encode(requestUrl));


### PR DESCRIPTION
Prior to this change, when create a request in process and user member in space mentioned in 'Who can manage the process' of the process and enabled 'For process manager - A new request has been created' notifs for mails, check received mail , this mail notification contains HTML tags. To fix this problem, remove the <p> tag that was created while typing a description. after this change, Mail notification escaped HTML tags.

(cherry picked from commit 75249901939d570a54a99f2668e2f275d18ffd0a)