### PR TITLE
fix: Only members of managing spaces should receive notifications of requests - EXO-67218 

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/notification/plugin/CreateRequestPlugin.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/notification/plugin/CreateRequestPlugin.java
@@ -40,7 +40,7 @@ public class CreateRequestPlugin extends BaseNotificationPlugin {
     String requestDescription = notificationContext.value(NotificationArguments.REQUEST_DESCRIPTION);
     String requestUrl = notificationContext.value(NotificationArguments.REQUEST_URL);
     String workflowProjectId = notificationContext.value(NotificationArguments.WORKFLOW_PROJECT_ID);
-    List<String> receivers = NotificationUtils.getReceivers(Long.parseLong(workflowProjectId), requester, true);
+    List<String> receivers = NotificationUtils.getReceivers(Long.parseLong(workflowProjectId), requester, false);
     return NotificationInfo.instance()
                            .setFrom(requester)
                            .to(receivers)

--- a/processes-services/src/test/java/org/exoplatform/processes/notification/plugin/CreateRequestPluginTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/notification/plugin/CreateRequestPluginTest.java
@@ -69,7 +69,7 @@ public class CreateRequestPluginTest {
     List<String> receivers = new ArrayList<>();
     receivers.add("user1");
     receivers.add("user2");
-    NOTIFICATION_UTILS.when(() -> NotificationUtils.getReceivers(1l , "root", true)).thenReturn(receivers);
+    NOTIFICATION_UTILS.when(() -> NotificationUtils.getReceivers(1l , "root", false)).thenReturn(receivers);
     NotificationInfo notificationInfo = createRequestPlugin.makeNotification(ctx);
     assertEquals("root", notificationInfo.getValueOwnerParameter(NotificationArguments.REQUEST_CREATOR.getKey()));
     assertEquals("http://exoplatfrom.com/dw/tasks/projectDetail/1",


### PR DESCRIPTION
Before this change, Process administrators and members of process managing spaces received notification of created requests After this change, only members of managing spaces receive notifications of created requests