### PR TITLE
fix: add access for external users for process page and portlet - EXO-69494

### DIFF
--- a/processes-webapp/src/main/webapp/WEB-INF/conf/processes/app-center-configuration.xml
+++ b/processes-webapp/src/main/webapp/WEB-INF/conf/processes/app-center-configuration.xml
@@ -55,6 +55,9 @@
                                 <value>
                                     <string>*:/platform/users</string>
                                 </value>
+                                <value>
+                                    <string>*:/platform/externals</string>
+                                </value>
                             </collection>
                         </field>
                         <field name="system">

--- a/processes-webapp/src/main/webapp/WEB-INF/conf/processes/dynamic-container-configuration.xml
+++ b/processes-webapp/src/main/webapp/WEB-INF/conf/processes/dynamic-container-configuration.xml
@@ -48,6 +48,9 @@
                                 <value>
                                     <string>*:/platform/users</string>
                                 </value>
+                                <value>
+                                    <string>*:/platform/externals</string>
+                                </value>
                             </collection>
                         </field>
                         <field name="title">

--- a/processes-webapp/src/main/webapp/WEB-INF/conf/processes/portal/portal/global/pages.xml
+++ b/processes-webapp/src/main/webapp/WEB-INF/conf/processes/portal/portal/global/pages.xml
@@ -23,13 +23,13 @@
     <page>
         <name>processes</name>
         <title>processes</title>
-        <access-permissions>*:/platform/users</access-permissions>
+        <access-permissions>*:/platform/users;*:/platform/externals</access-permissions>
         <edit-permission>*:/platform/administrators</edit-permission>
         <container cssClass="singlePageApplication" id="processesParentContainer" template="system:/groovy/portal/webui/container/UIContainer.gtmpl">
             <access-permissions>Everyone</access-permissions>
             <container id="top-processes-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">
                 <name>top-processes-container</name>
-                <access-permissions>*:/platform/users</access-permissions>
+                <access-permissions>Everyone</access-permissions>
                 <factory-id>addonContainer</factory-id>
             </container>
             <container id="processes-container" template="system:/groovy/portal/webui/container/UIAddOnContainer.gtmpl">


### PR DESCRIPTION
Before this change, external users  are not able to access the process application
After this change, the external users have other permission to access the process app and the process application