### PR TITLE
TASK-70317: can't edit oform file when creating a request

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
@@ -56,7 +56,7 @@ along with this program. If not, see <http://www.gnu.org/licenses/>.
             :attachment="attachment"
             :can-access="attachment.acl && attachment.acl.canAccess"
             :allow-to-detach="false"
-            :open-in-editor="!isMobileDevice"
+            :open-in-editor="true"
             :is-file-editable="isFileEditable(attachment)"
             allow-to-preview
             small-attachment-icon />
@@ -130,9 +130,6 @@ export default {
     },
     attachmentsLength() {
       return this.attachments && this.attachments.length > 0 ? `(${this.attachments.length})` : '';
-    },
-    isMobileDevice() {
-      return (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent));
     }
   },
   created() {


### PR DESCRIPTION
Prior to this, when creating a request using a mobile device, the user couldn't edit the oform because it is opened in the viewer, The fix changed this behaviour to open attachments for process in the editor. 