### PR TITLE
fix: Redirect should be to related to current page after editing attachment - EXO-71706

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/CreateDocumentForm.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/CreateDocumentForm.vue
@@ -137,7 +137,7 @@ export default {
         doc.date = doc.created;
         this.$root.$emit('add-new-created-form-document', doc);
         this.restInput();
-        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${doc.id}`, '_blank');
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${doc.id}&backTo=${window.location.pathname}`, '_blank');
       }
     },
     restInput() {


### PR DESCRIPTION
Before this fix, after editing a document, the back button always opens the location of the document in the document app.
In process app the back button should open the location of the request. this fix add a bew path param whith the go back location to be opened when clicking on the back button on the oo editor