### PR TITLE
fix: Process drawer are not correctly displayed - EXO-72534

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkDrawer.vue
@@ -3,6 +3,7 @@
     <exo-drawer
       @closed="close"
       ref="work"
+      attached
       right>
       <template slot="title">
         <v-container

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
@@ -5,6 +5,7 @@
       :confirm-close-labels="confirmCloseLabels"
       @closed="close()"
       ref="workFlow"
+      attached
       id="addWorkFlowDrawer"
       right>
       <template #title>


### PR DESCRIPTION
Before this fix, process drawer are not used due to missing css. This change comes from the exo-drawer component modification. Process drawer have not the new 'attached' attribut.

This commit add the attached attribute on drawers