### PR TITLE
fix: Redirect should be to related to current page after editing attachment - EXO-71706

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/notification-extension/components/RequestCommentPlugin.vue
+++ b/processes-webapp/src/main/webapp/vue-app/notification-extension/components/RequestCommentPlugin.vue
@@ -28,7 +28,7 @@
       </div>
       <div class="text-truncate">
         <v-icon size="14" class="me-1">fa-comment</v-icon>
-        <span v-sanitized-html="requestComment" />
+        <span v-sanitized-html="requestComment"></span>
       </div>
     </template>
   </user-notification-template>

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkDrawer.vue
@@ -301,6 +301,7 @@ export default {
         this.viewMode = false;
         this.editDraft = true;
         this.firstCreation = false;
+        this.$root.$emit('update-url-path', 'draftDetails', `/myRequests/draftDetails/${this.work.id}`);
         this.$root.$on('can-show-request-editor',() => {
           this.showEditor = true;
           window.setTimeout(() => {

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkDrawer.vue
@@ -286,7 +286,7 @@ export default {
     showRequestEditor() {
       this.showEditor = !this.showEditor;
     },
-    open(object, mode, isDraft) {
+    open(object, mode, isDraft, allowSave) {
       if (mode === 'create_work') {
         this.work = {};
         this.work.workFlow = object;
@@ -322,7 +322,7 @@ export default {
         entityType: this.entityType
       });
       this.initEditor();
-      this.attachmentsUpdated = false;
+      this.attachmentsUpdated = allowSave;
       this.$refs.work.open();
     },
     initEditor() {

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -100,6 +100,7 @@ export default {
       messageAction: null,
       messageTargetModel: null,
       messageTimer: null,
+      draftId: null,
     };
   },
   beforeCreate() {
@@ -339,6 +340,10 @@ export default {
         this.$root.$emit('close-work-drawer');
         this.$root.$emit('hideTaskComment');
       }
+      if (path.includes('/myRequests/draftDetails')) {
+        this.tab = 1;
+        this.draftId =path.split('draftDetails/')[1].split(/\D/)[0];
+      }
       if (path.includes('/requestDetails') && !path.endsWith('/comments')) {
         this.tab = 1;
         const workId = path.split('requestDetails/')[1].split(/\D/)[0];
@@ -464,6 +469,13 @@ export default {
       this.loading = true;
       return this.$processesService.getWorkDrafts(null, 0, 0, expand).then(drafts => {
         this.allWorkDrafts = drafts || [];
+        if (this.draftId) {
+          const draft = this.allWorkDrafts.find((element) => element.id.toString() === this.draftId.toString());
+          if (draft){
+            this.$root.$emit('open-add-work-drawer', {object: draft, mode: 'edit_work_draft'});
+            this.handleUpdateUrlPath('draftDetails', `/myRequests/draftDetails/${draft.id}`);
+          }
+        }
         if (this.query){
           this.workDrafts = this.allWorkDrafts.filter(elem=>{
             return elem.description && elem.description.replace(/\s/g,'').replace(/<\/?[^>]+(>|$)/gi, '').includes(this.query.replace(/\s/g,''));
@@ -526,6 +538,7 @@ export default {
             this.displayMessage({type: 'success', message: this.$t('processes.workDraft.add.success.message')});
           }
           this.workDrafts.unshift(draft);
+          this.$root.$emit('update-url-path', 'draftDetails', `/myRequests/draftDetails/${draft.id}`);
         }
       }).catch(() => {
         this.displayMessage({type: 'error', message: this.$t('processes.workDraft.save.error.message')});

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -101,6 +101,7 @@ export default {
       messageTargetModel: null,
       messageTimer: null,
       draftId: null,
+      updated: false,
     };
   },
   beforeCreate() {
@@ -201,7 +202,7 @@ export default {
       }
       this.work = event.object;
       this.workComments = event.object.comments;
-      this.$refs.addWork.open(event.object, event.mode, event.isDraft);
+      this.$refs.addWork.open(event.object, event.mode, event.isDraft,event.allowSave);
     });
     this.$root.$on('open-workflow-drawer', event => {
       this.$refs.addWorkFlow.open(event.workflow, event.mode);
@@ -359,6 +360,13 @@ export default {
         const workId = path.split('requestDetails/')[1].split(/\D/)[0];
         this.openWorkComments(workId);
       }
+      if (path.includes('/myRequests/draftDetails')||path.includes('/myRequests/requestDetails')) {
+        const currentUrlSearchParams = window.location.search;
+        const queryParams = new URLSearchParams(currentUrlSearchParams);
+        if (queryParams.has('updated')) {
+          this.updated = queryParams.get('updated') === 'true';
+        }
+      }
     },
     openCreateWork(workflowId) {
       this.$processesService.getWorkflowById(workflowId, '').then(workflow => {
@@ -472,7 +480,7 @@ export default {
         if (this.draftId) {
           const draft = this.allWorkDrafts.find((element) => element.id.toString() === this.draftId.toString());
           if (draft){
-            this.$root.$emit('open-add-work-drawer', {object: draft, mode: 'edit_work_draft'});
+            this.$root.$emit('open-add-work-drawer', {object: draft, mode: 'edit_work_draft', allowSave: this.updated});
             this.handleUpdateUrlPath('draftDetails', `/myRequests/draftDetails/${draft.id}`);
           }
         }

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/CreateDocumentForm.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/CreateDocumentForm.vue
@@ -137,7 +137,7 @@ export default {
         doc.date = doc.created;
         this.$root.$emit('add-new-created-form-document', doc);
         this.restInput();
-        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${doc.id}`, '_blank');
+        window.open(`${eXo.env.portal.context}/${eXo.env.portal.portalName}/oeditor?docId=${doc.id}&backTo=${window.location.pathname}`, '_blank');
       }
     },
     restInput() {


### PR DESCRIPTION
Before this fix, after editing a document, the back button always opens the location of the document in the document app.
In process app the back button should open the location of the request. this fix add a bew path param whith the go back location to be opened when clicking on the back button on the oo editor