### PR TITLE
fix: Process creator can't visualize attachments added to his created request - EXO-72858 (#383)

### DIFF
--- a/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImplTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImplTest.java
@@ -106,8 +106,11 @@ public class ProcessesAttachmentServiceImplTest {
     ConversationState conversationState = mock(ConversationState.class);
     CONVERSATION_STATE.when(() -> ConversationState.getCurrent()).thenReturn(conversationState);
     Identity identity = mock(Identity.class);
+    org.exoplatform.social.core.identity.model.Identity userIdentity = mock(org.exoplatform.social.core.identity.model.Identity.class);
     when(conversationState.getIdentity()).thenReturn(identity);
+    when(identityManager.getIdentity(any())).thenReturn(userIdentity);
     when(identity.getUserId()).thenReturn("test");
+    when(userIdentity.getRemoteId()).thenReturn("test");
   }
 
   @Test


### PR DESCRIPTION
Prior to this fix, if a user not a member of the process managers space creates a request without attaching documents, and one of the process managers adds an attachment to the request, the user creator of the request can't see the attached document.
this is due to the fact that a process manager created the entity folder and the user will not have permission to access it.
this commit fixes this case by creating the entity folder when the request is created and adding the needed permission to the user.