### PR TITLE
fix: Ckeditor missing layout options in process app - EXO-73701

### DIFF
--- a/processes-webapp/src/main/webapp/skin/less/processes.less
+++ b/processes-webapp/src/main/webapp/skin/less/processes.less
@@ -514,6 +514,20 @@
     margin-left: -8px ~'; /** orientation=lt */ ';
     margin-right: -8px ~'; /** orientation=rt */ ';
   }
+  
+  .work-message{
+    position: relative;
+    .cke_bottom, .cke_top {
+      background: transparent;
+      height: 30px;
+      .cke_button_icon {
+        filter: opacity(0.2);
+      }
+    }
+    .cke_focus .cke_button_icon {
+      filter: opacity(0.4);
+    }
+  }
 }
 
 .processes-work-menu-icon {


### PR DESCRIPTION
Before this change, when go to process and put cursor in (message to the manager) field, the layout option in the composer are missing(bold/italic/bullted list/numbered list/bloc quote) same in edit mode. After this change, the layout options (bold/italic/bullted list/numbered list/bloc quote) are available in create and edit mode.

(cherry picked from commit 00f589478a7e8f3ee7a5ee8cd8abf5f133063ac9)