### PR TITLE
fix: [BUG] Process :Document+parent Folder lost in case of Upload from existing document (new process/new request) - EXO-74485

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImpl.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImpl.java
@@ -204,7 +204,15 @@ public class ProcessesAttachmentServiceImpl implements ProcessesAttachmentServic
         Map<String, String[]> unmodifiablePermissions = Collections.unmodifiableMap(permissions);
         ((ExtendedNode) destNode).setPermissions(unmodifiablePermissions);
         String destPath = destNode.getPath().concat("/").concat(attachmentNode.getName());
-        if (copy) {
+        if (!copy && attachmentNode.getPath().contains("temp/"+destEntityType)) {
+          Node sourceEntityIdNode = attachmentNode.getParent();
+          session.move(attachmentNode.getPath(), destPath);
+          if (attachments.size() - 1 == index && sourceEntityIdNode != null
+                  && sourceEntityIdNode.getPrimaryNodeType().isNodeType(NodetypeConstant.NT_FOLDER)) {
+            sourceEntityIdNode.remove();
+          }
+          session.save();
+        } else {
           session.save();
           Workspace workspace = session.getWorkspace();
           workspace.copy(attachmentNode.getPath(), destPath);
@@ -212,14 +220,6 @@ public class ProcessesAttachmentServiceImpl implements ProcessesAttachmentServic
           processDocument(copyNode, currentUser);
           Attachment copyAttachment = attachmentService.getAttachmentById(copyNode.getUUID());
           updatedAttachments.put(index, copyAttachment);
-        } else {
-          Node sourceEntityIdNode = attachmentNode.getParent();
-          session.move(attachmentNode.getPath(), destPath);
-          if (attachments.size() - 1 == index && sourceEntityIdNode != null
-              && sourceEntityIdNode.getPrimaryNodeType().isNodeType(NodetypeConstant.NT_FOLDER)) {
-            sourceEntityIdNode.remove();
-          }
-          session.save();
         }
       } catch (Exception e) {
         LOG.error("Error while moving or copying attachments", e);

--- a/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImplTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImplTest.java
@@ -185,11 +185,11 @@ public class ProcessesAttachmentServiceImplTest {
     when(extendedNode.canAddMixin(NodetypeConstant.EXO_PRIVILEGEABLE)).thenReturn(true);
     when(extendedNode.getName()).thenReturn("test");
     when(node.getName()).thenReturn("test");
-    when(node.getPath()).thenReturn("srcPath");
+    when(node.getPath()).thenReturn("srcPath/temp/workdraft");
     when(extendedNode.getPath()).thenReturn("destPath");
     when(node.getParent()).thenReturn(node);
     processesAttachmentService.moveAttachmentsToEntity(1L, 1L, "workflow", 1L, "workdraft", 1L);
-    verify(session, times(1)).move("srcPath", "destPath/test");
+    verify(session, times(1)).move("srcPath/temp/workdraft", "destPath/test");
 
   }
 

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
@@ -120,7 +120,7 @@ export default {
       return {
         entityType: this.entityType,
         entityId: this.entityId,
-        defaultFolder: 'Documents',
+        defaultFolder: this.entityId ? `Documents/${this.entityType}/${this.entityId}`:`Documents/temp/${this.entityType}`,
         sourceApp: 'processesApp',
         attachments: JSON.parse(JSON.stringify(this.attachments)),
         spaceId: this.workflowParentSpace && this.workflowParentSpace.id,


### PR DESCRIPTION
Prior to this fix, when user upload attachments to a workflow/request  from existing documents, the documents were lost from the source location, this is due to that the service moves the documents from the source to the entity folder (this is okay if documents are uploaded from external location), this change fix this by changing the location of external uploads to a temp folder and allowing the move only if documents are in this folder, otherwise, a copy will be performed