### PR TITLE
fix: [BUG] Process :Document+parent Folder lost in case of Upload from existing document (new process/new request) - EXO-74485

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImpl.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImpl.java
@@ -167,7 +167,8 @@ public class ProcessesAttachmentServiceImpl implements ProcessesAttachmentServic
     final Session session = jcrSession;
     final ProjectDto project = projectDto;
     IntStream.range(0, attachments.size()).forEach(index -> {
-      String attachmentId = attachments.get(index).getId();
+      Attachment attachment = attachments.get(index);
+      String attachmentId = attachment.getId();
       try {
         DriveData driveData;
         Node rootNode;
@@ -204,7 +205,7 @@ public class ProcessesAttachmentServiceImpl implements ProcessesAttachmentServic
         Map<String, String[]> unmodifiablePermissions = Collections.unmodifiableMap(permissions);
         ((ExtendedNode) destNode).setPermissions(unmodifiablePermissions);
         String destPath = destNode.getPath().concat("/").concat(attachmentNode.getName());
-        if (!copy && attachmentNode.getPath().contains("temp/"+destEntityType)) {
+        if (!copy && !attachment.isEXoDrive()) {
           Node sourceEntityIdNode = attachmentNode.getParent();
           session.move(attachmentNode.getPath(), destPath);
           if (attachments.size() - 1 == index && sourceEntityIdNode != null

--- a/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImplTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImplTest.java
@@ -185,11 +185,11 @@ public class ProcessesAttachmentServiceImplTest {
     when(extendedNode.canAddMixin(NodetypeConstant.EXO_PRIVILEGEABLE)).thenReturn(true);
     when(extendedNode.getName()).thenReturn("test");
     when(node.getName()).thenReturn("test");
-    when(node.getPath()).thenReturn("srcPath/temp/workdraft");
+    when(node.getPath()).thenReturn("srcPath");
     when(extendedNode.getPath()).thenReturn("destPath");
     when(node.getParent()).thenReturn(node);
     processesAttachmentService.moveAttachmentsToEntity(1L, 1L, "workflow", 1L, "workdraft", 1L);
-    verify(session, times(1)).move("srcPath/temp/workdraft", "destPath/test");
+    verify(session, times(1)).move("srcPath", "destPath/test");
 
   }
 

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
@@ -120,7 +120,7 @@ export default {
       return {
         entityType: this.entityType,
         entityId: this.entityId,
-        defaultFolder: this.entityId ? `Documents/${this.entityType}/${this.entityId}`:`Documents/temp/${this.entityType}`,
+        defaultFolder: 'Documents',
         sourceApp: 'processesApp',
         attachments: JSON.parse(JSON.stringify(this.attachments)),
         spaceId: this.workflowParentSpace && this.workflowParentSpace.id,


### PR DESCRIPTION
Prior to this fix, when user upload attachments to a workflow/request  from existing documents, the documents were lost from the source location, this is due to that the service moves the documents from the source to the entity folder (this is okay if documents are uploaded from external location), this change fix this by changing the location of external uploads to a temp folder and allowing the move only is the documents are in this folder, otherwise, a copy will be performed