### PR TITLE
fix: [BUG] Process :Document+parent Folder lost in case of Upload from existing document (new process/new request) - EXO-74485 (#395)

### DIFF
--- a/processes-api/src/main/java/org/exoplatform/processes/model/Work.java
+++ b/processes-api/src/main/java/org/exoplatform/processes/model/Work.java
@@ -19,8 +19,10 @@ package org.exoplatform.processes.model;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.exoplatform.services.attachments.model.Attachment;
 
 import java.util.Date;
+import java.util.List;
 
 @Data
 @AllArgsConstructor
@@ -60,6 +62,8 @@ public class Work {
   private Long     draftId;
 
   private WorkFlow workFlow;
+
+  private List<Attachment> attachments;
 
   /**
    * constructor for Work task object

--- a/processes-api/src/main/java/org/exoplatform/processes/service/ProcessesAttachmentService.java
+++ b/processes-api/src/main/java/org/exoplatform/processes/service/ProcessesAttachmentService.java
@@ -2,6 +2,8 @@ package org.exoplatform.processes.service;
 
 import org.exoplatform.services.attachments.model.Attachment;
 
+import java.util.List;
+
 public interface ProcessesAttachmentService {
 
     /**
@@ -26,6 +28,26 @@ public interface ProcessesAttachmentService {
      * @param projectId task project id
      */
     void moveAttachmentsToEntity(Long userId, Long sourceEntityId, String sourceEntityType, Long destEntityId, String destEntityType, Long projectId);
+
+
+    /**
+     * Move attachments from source entity to a dest entity
+     *
+     * @param attachments list of attachment
+     * @param userId user identity id
+     * @param sourceEntityId source entity of attachments
+     * @param sourceEntityType target entity type to attach files from source entity
+     * @param destEntityId target entity id
+     * @param destEntityType target entity type
+     * @param projectId task project id
+     */
+    void moveAttachmentsToEntity(List<Attachment> attachments,
+                                 Long userId,
+                                 Long sourceEntityId,
+                                 String sourceEntityType,
+                                 Long destEntityId,
+                                 String destEntityType,
+                                 Long projectId);
 
     /**
      * Copy attachments from source entity to a dest entity

--- a/processes-services/src/main/java/org/exoplatform/processes/rest/model/WorkEntity.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/rest/model/WorkEntity.java
@@ -18,10 +18,12 @@
 package org.exoplatform.processes.rest.model;
 
 import java.util.Date;
+import java.util.List;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.exoplatform.services.attachments.model.Attachment;
 
 @Data
 @AllArgsConstructor
@@ -61,6 +63,8 @@ public class WorkEntity {
   private Long           taskId;
 
   private Boolean        isDraft;
+
+  private List<Attachment> attachments;
 
   public WorkEntity(long id,
                     String title,

--- a/processes-services/src/main/java/org/exoplatform/processes/rest/util/EntityBuilder.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/rest/util/EntityBuilder.java
@@ -176,6 +176,7 @@ public class EntityBuilder {
                          workEntity.getIsDraft(),
                          workEntity.getDraftId(),
                          workEntity.getProjectId());
+    work.setAttachments(workEntity.getAttachments());
     if (workEntity.getWorkFlow() != null) {
       try {
         WorkFlow workFlow = processesService.getWorkFlow(workEntity.getWorkFlow().getId());
@@ -208,6 +209,7 @@ public class EntityBuilder {
     if (expandProperties.contains("comments")) {
       // TODO: Add comments
     }
+    workEntity.setAttachments(work.getAttachments());
 
     try {
       workEntity.setDescription(HTMLSanitizer.sanitize(work.getDescription()));

--- a/processes-services/src/main/java/org/exoplatform/processes/storage/ProcessesStorageImpl.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/storage/ProcessesStorageImpl.java
@@ -397,7 +397,8 @@ public class ProcessesStorageImpl implements ProcessesStorage {
       TaskDto taskDto = createWorkTask(work, identity);
       ProjectDto projectDto = taskDto.getStatus().getProject();
       if (work.getDraftId() != null) {
-        processesAttachmentService.moveAttachmentsToEntity(userId,
+        processesAttachmentService.moveAttachmentsToEntity(work.getAttachments(),
+                                                           userId,
                                                            work.getDraftId(),
                                                            WORK_DRAFT_ENTITY_TYPE,
                                                            taskDto.getId(),

--- a/processes-services/src/test/java/org/exoplatform/processes/storage/ProcessesStorageImplTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/storage/ProcessesStorageImplTest.java
@@ -336,12 +336,13 @@ public class ProcessesStorageImplTest {
     work.setIsDraft(true);
     work.setId(0);
     work.setDraftId(1L);
+    work.setAttachments(new ArrayList<Attachment>());
     WorkFlow workFlow = new WorkFlow();
     workFlow.setProjectId(1L);
     when(taskDto.getId()).thenReturn(1L);
     when(workDraftDAO.find(1L)).thenReturn(WorkEntity);
     processesStorage.saveWork(work, 1L);
-    verify(processesAttachmentService, times(1)).moveAttachmentsToEntity(1L, 1L, "workdraft", 1L, "task", 1L);
+    verify(processesAttachmentService, times(1)).moveAttachmentsToEntity(new ArrayList<Attachment>(), 1L, 1L, "workdraft", 1L, "task", 1L);
     verify(workDraftDAO, times(1)).delete(WorkEntity);
     when(projectService.getProject(work.getProjectId())).thenThrow(EntityNotFoundException.class);
 

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkDrawer.vue
@@ -358,6 +358,7 @@ export default {
         this.work.draftId = this.work.id;
         this.work.id = 0;
       }
+      this.work.attachments=this.attachments;
       this.$root.$emit('add-work', this.work);
     },
     toWorkDraft(work) {

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
@@ -145,13 +145,9 @@ export default {
         });
     }
     document.addEventListener('attachment-added', event => {
-      if (this.editMode) {
-        this.initEntityAttachmentsList();
-      } else {
-        this.attachments.push(event.detail.attachment);
-      }
+      this.attachments.push(event.detail.attachment);
       this.subscribeDocument(event.detail.attachment.id);
-      this.$root.$emit('attachments-updated');
+      this.$root.$emit('attachments-updated',this.attachments);
     });
     this.$root.$on('add-new-created-form-document', (doc) => {
       this.attachments.push(doc);


### PR DESCRIPTION
Prior to this fix, when user uploaded attachments to a workflow/request  from existing documents, the documents were lost from the source location, this is due to that the service moves the documents from the source to the entity folder (this is okay if documents are uploaded from external location), this change fix this by adding the information to the attachment entity and allowing the move only if the documents is not added from exo drives, otherwise a copy will be performed