### PR TITLE
fix: [Process Space Managers] members of managing space don't have the 3 dots menu displayed - EXO-74880 .

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/Utils/EntityMapper.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/Utils/EntityMapper.java
@@ -99,18 +99,17 @@ public class EntityMapper {
       for (String manager : workFlowEntity.getManager()) {
         if (member.contains(manager)) {
           permission.setCanAddRequest(true);
-          permission.setCanDelete(true);
-          permission.setCanEdit(true);
           break;
         }
       }
       for (String participator : workFlowEntity.getParticipator()) {
         if (member.equals(participator)) {
           permission.setCanAccess(true);
+          permission.setCanEdit(true);
           break;
         }
       }
-      if (member.contains(PROCESSES_GROUP) && !permission.isCanEdit()) {
+      if (member.contains(PROCESSES_GROUP)) {
         permission.setCanDelete(true);
         permission.setCanEdit(true);
       }

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
@@ -47,6 +47,7 @@
             </v-list-item-title>
           </v-list-item>
           <v-list-item
+            v-if="workflow.acl.canDelete"
             @click="deleteWorkflow">
             <v-list-item-title>
               <v-icon size="13" class="processes-work-menu-icon mt-1">


### PR DESCRIPTION
Before this change, when set spaceX as processA manager space and userX member of spaceX access to process App and list porcessest, userX doesn't have the 3 dots menu displayed on. To resolve this problem, add isCanEdit and isCanDelete permission to all spaceX members and add to the check for who the 3 dots button is displayed if the user can edit it then he has permission to display the button. After this change, the 3 dots menu of processA is displayed for any spaceX member.