### PR TITLE
fix: members of managing space don't have the 3 dots menu displayed - EXO-74880

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/Utils/EntityMapper.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/Utils/EntityMapper.java
@@ -26,6 +26,8 @@ import org.exoplatform.task.dto.TaskDto;
 public class EntityMapper {
   private static final Log LOG = ExoLogger.getLogger(EntityMapper.class);
 
+  private static final String PROCESSES_GROUP =  "/platform/processes";
+
   private EntityMapper() {
   }
 
@@ -97,6 +99,8 @@ public class EntityMapper {
       for (String manager : workFlowEntity.getManager()) {
         if (member.contains(manager)) {
           permission.setCanAddRequest(true);
+          permission.setCanDelete(true);
+          permission.setCanEdit(true);
           break;
         }
       }
@@ -106,7 +110,7 @@ public class EntityMapper {
           break;
         }
       }
-      if (member.contains("/platform/processes")) {
+      if (member.contains(PROCESSES_GROUP) && !permission.isCanEdit()) {
         permission.setCanDelete(true);
         permission.setCanEdit(true);
       }

--- a/processes-services/src/main/java/org/exoplatform/processes/Utils/EntityMapper.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/Utils/EntityMapper.java
@@ -99,18 +99,17 @@ public class EntityMapper {
       for (String manager : workFlowEntity.getManager()) {
         if (member.contains(manager)) {
           permission.setCanAddRequest(true);
-          permission.setCanDelete(true);
-          permission.setCanEdit(true);
           break;
         }
       }
       for (String participator : workFlowEntity.getParticipator()) {
         if (member.equals(participator)) {
           permission.setCanAccess(true);
+          permission.setCanEdit(true);
           break;
         }
       }
-      if (member.contains(PROCESSES_GROUP) && !permission.isCanEdit()) {
+      if (member.contains(PROCESSES_GROUP)) {
         permission.setCanDelete(true);
         permission.setCanEdit(true);
       }

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
@@ -8,7 +8,7 @@
       <v-menu
         v-model="showMenu"
         transition="slide-x-reverse-transition"
-        v-if="isProcessesManager"
+        v-if="isProcessesManager || workflow.acl.canEdit"
         :ref="'menu' + workflow.id"
         :close-on-content-click="false"
         bottom

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
@@ -45,6 +45,7 @@
             </v-list-item-title>
           </v-list-item>
           <v-list-item
+            v-if="workflow.acl.canDelete"
             @click="deleteWorkflow">
             <v-list-item-title>
               <v-icon size="13" class="processes-work-menu-icon mt-1">


### PR DESCRIPTION
Before this change, when set spaceX as processA manager space and userX member of spaceX access to process App and list porcessest, userX doesn't have the 3 dots menu displayed on. To resolve this problem, add isCanEdit and isCanDelete permission to all spaceX members and add to the check for who the 3 dots button is displayed if the user can edit it then he has permission to display the button. After this change, the 3 dots menu of processA is displayed for any spaceX member.