### PR TITLE
fix: [Process-Edit process] process disappears - EXO-75002 .

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
@@ -534,7 +534,6 @@ export default {
       this.workflow.requestsCreators = this.workflowRequest;
       this.workflow.illustrativeAttachment = this.illustrativeImage;
       this.$root.$emit('update-workflow',this.workflow);
-      this.$root.$emit('refresh-works');
     },
     deleteIllustrative(){
       this.illustrativeInput = null;

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowList.vue
@@ -237,12 +237,31 @@ export default {
     this.$root.$on('workflow-updated', (workflow) => {
       workflow = JSON.parse(workflow);
       const index = this.workflowList.map(workflow => workflow.id).indexOf(workflow.id);
-      if (this.filter.value === 'activated' && workflow.enabled) {
+      switch (this.filter.value) {
+      case 'activated':
+        if (workflow.enabled) {
+          this.workflowList.splice(index, 1, workflow);
+        } else {
+          this.workflowList.splice(index, 1);
+        }
+        break;
+      case 'deactivated':
+        if (!workflow.enabled) {
+          this.workflowList.splice(index, 1, workflow);
+        } else {
+          this.workflowList.splice(index, 1);
+        }
+        break;
+      case 'manager':
+        if (workflow.acl.canEdit) {
+          this.workflowList.splice(index, 1, workflow);
+        } else {
+          this.workflowList.splice(index, 1);
+        }
+        break;
+      default:
         this.workflowList.splice(index, 1, workflow);
-      } else if (this.filter.value === 'deactivated' && !workflow.enabled) {
-        this.workflowList.splice(index, 1, workflow);
-      } else {
-        this.workflowList.splice(index, 1);
+        break;
       }
     });
     this.$root.$on('workflow-removed', (workflow) => {


### PR DESCRIPTION
Before this change, when create processA and save and edit processA, ProcessA disappears unless page is refreshed. To resolve this problem, after the edit add the conditions where the filter equals (all or Imanage) to change the workflow list, the old workflow by the edited workflow. After this change, processA is displayed without needing to refresh page.