### PR TITLE
fix: [Porcess app in sapce] layout issue - EXO-75153.

### DIFF
--- a/processes-webapp/src/main/webapp/skin/less/processes.less
+++ b/processes-webapp/src/main/webapp/skin/less/processes.less
@@ -5,6 +5,10 @@
 
   overflow-x: hidden;
   
+  .application-body {
+    min-height: auto !important;
+  } 
+  
   .cursor-default {
     cursor: default;
   }


### PR DESCRIPTION
Before this change, when add new item in spaceX called Process in Process then add new page having process application and save, a big white bloc is displayed and process elements are displayed below. To resolve this problem, add a min-height: auto style for the application-body class. After this change, Process application is displayed with no additional white blocks.