### PR TITLE
fix: [Process-Edit process] process disappears - EXO-75002 . (#404)

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
@@ -534,6 +534,7 @@ export default {
       this.workflow.requestsCreators = this.workflowRequest;
       this.workflow.illustrativeAttachment = this.illustrativeImage;
       this.$root.$emit('update-workflow',this.workflow);
+      this.$root.$emit('refresh-works');
     },
     deleteIllustrative(){
       this.illustrativeInput = null;


### PR DESCRIPTION
Before this change, when create processA and save and edit processA, ProcessA disappears unless page is refreshed. To resolve this problem, after the edit launches the refresh-works event. After this change, processA is displayed without needing to refresh page.

(cherry picked from commit b3c005ba97a60ce15ea53e10981ebbc5abbb7d43)