### PR TITLE
fix: Make Adaptations on Unit Tests switch Social API Change - MEED-7814 - Meeds-io/MIPs#160

### DIFF
--- a/processes-services/src/test/java/org/exoplatform/processes/rest/EntityBuilderTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/rest/EntityBuilderTest.java
@@ -82,7 +82,7 @@ public class EntityBuilderTest {
     StatusService statusService = mock(StatusService.class);
     List<WorkFlow> workFlows = new ArrayList<>();
     Space space = new Space();
-    space.setId("test");
+    space.setId("12");
     space.setPrettyName("test");
     space.setDisplayName("test");
     WorkFlow workFlow = new WorkFlow();


### PR DESCRIPTION
This change ensures to mock the space using a Long id instead of text.

Resolves https://github.com/Meeds-io/MIPs/issues/160