### PR TITLE
fix: request never created if image is pasted on content - EXO-76645

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/RequestEditor.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/RequestEditor.vue
@@ -138,6 +138,12 @@ export default {
           blur: function (event) {
             self.$emit('blur', event);
           },
+          paste: function (event) {
+            const pastedData = (event.data && event.data.dataValue) || '';
+            const cleanedData = pastedData.replace(/<img[^>]*>|<video[^>]*>|<audio[^>]*>/g, '');
+            event.editor.insertHtml(cleanedData);
+            event.cancel();
+          },
           destroy: function () {
             self.inputVal = '';
             self.editor = null;


### PR DESCRIPTION
Before this change, when click on process to open request drawer and on request content paste an image, error message displayed and submit button load infinitely. To resolve this problem, add an event handler to detect paste actions and perform media cleanup in the pasted content before displaying it in the editor. After this change, no media content is possible to be pasted on request content.

(cherry picked from commit 785b49fd265a8150006feec8cc1738029d0bf168)