### PR TITLE
fix:  Create request: Process name isn't displayed on drawer - EXO-76818

### DIFF
--- a/processes-webapp/src/main/webapp/skin/less/processes.less
+++ b/processes-webapp/src/main/webapp/skin/less/processes.less
@@ -322,6 +322,15 @@
   .work-status {
     max-width: 85%;
   }
+
+  .work-title {
+    background: rgba(150, 182, 219, 0.67) 0 0 no-repeat padding-box;
+    border-radius: 19px;
+    max-width: 90%;
+    width: fit-content;
+    top: 5px;
+    position: relative;
+  }
   .v-autocomplete.identitySuggester {
     width: 290px;
 
@@ -418,15 +427,6 @@
 
     .v-counter {
       text-align: end;
-    }
-
-    .work-title {
-      background: rgba(96, 147, 204, 0.67) 0 0 no-repeat padding-box;
-      border-radius: 19px;
-      max-width: 90%;
-      width: fit-content;
-      top: 5px;
-      position: relative;
     }
 
     .col-work-title {


### PR DESCRIPTION
Prior to this fix, the process name is not visible on the request drawer, this is due to the fact that the title color is white and the needed class for the title background is not applied.
This change fixes this by redefining the  'work-title' class position in the less file to apply it to the drawer header.