### PR TITLE
fix: Process isn't displayed in I manage filter if I'm a member only in its management space - EXO-76971

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/dao/WorkFlowDAO.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/dao/WorkFlowDAO.java
@@ -55,33 +55,41 @@ public class WorkFlowDAO extends GenericDAOJPAImpl<WorkFlowEntity, Long> {
     String q = processesFilter.getQuery();
     Boolean enabled = processesFilter.getEnabled();
     Boolean manager = processesFilter.getManager();
+    boolean managerProcess = memberships.stream().anyMatch(m -> m.endsWith("platform/processes"));
+    String query = " ( workFlow.title like '%" + q + "%' OR workFlow.description like '%" + q + "%' OR workFlow.summary like '%" + q + "%' )";
     String queryString = "SELECT DISTINCT workFlow FROM WorkFlow workFlow";
-    if(memberships != null) {
-      queryString = queryString + " LEFT JOIN workFlow.manager manager "
-              + " LEFT JOIN workFlow.participator participator ";
-    }
-    if(StringUtils.isNotEmpty(q) || memberships != null || enabled != null){
-      queryString = queryString + " WHERE";
-      if (StringUtils.isNotEmpty(q)){
-        queryString = queryString + " ( workFlow.title like '%" + q + "%'";
-        queryString = queryString + " OR workFlow.description like '%" + q + "%'";
-        queryString = queryString + " OR workFlow.summary like '%" + q + "%' )";
-        queryString = queryString + " AND";
+    if (enabled != null || manager == true || managerProcess == false) {
+      if(memberships != null) {
+        if ( Boolean.FALSE.equals(manager)) {
+          queryString = queryString + " LEFT JOIN workFlow.manager manager";
+        }
+        queryString = queryString + " LEFT JOIN workFlow.participator participator";
       }
-      if ( enabled != null){
-        queryString = queryString + " workFlow.enabled = " + enabled;
-        queryString = queryString + " AND";
-      }
-      if ( memberships != null){
-        queryString = queryString + " ( manager IN ('"+String.join("','", getMembersShipGroup(memberships))+"') ";
-        if ( Boolean.FALSE.equals(manager)){
-          queryString = queryString + " OR participator IN ('"+String.join("','", memberships)+"')) ";
-        } else {
-          queryString = queryString + " AND participator IN ('"+String.join("','", memberships)+"')) ";
+      if(StringUtils.isNotEmpty(q) || memberships != null || enabled != null){
+        queryString = queryString + " WHERE";
+        if (StringUtils.isNotEmpty(q)){
+          queryString = queryString + query;
+          queryString = queryString + " AND";
+        }
+        if ( enabled != null){
+          queryString = queryString + " workFlow.enabled = " + enabled;
+          queryString = queryString + " AND";
+        }
+        if ( memberships != null){
+          if ( Boolean.FALSE.equals(manager)){
+            queryString = queryString + " ( manager IN ('"+String.join("','", getMembersShipGroup(memberships))+"') ";
+            queryString = queryString + " OR participator IN ('"+String.join("','", memberships)+"')) ";
+          } else {
+            queryString = queryString + " participator IN ('"+String.join("','", memberships)+"') ";
+          }
+        }
+        if (queryString.endsWith(" AND")) {
+          queryString = queryString.substring(0, queryString.length() - 4);
         }
       }
-      if (queryString.endsWith(" AND")) {
-        queryString = queryString.substring(0, queryString.length() - 4);
+    } else {
+      if (StringUtils.isNotEmpty(q)) {
+        queryString = queryString + " WHERE" + query;
       }
     }
 
@@ -90,7 +98,8 @@ public class WorkFlowDAO extends GenericDAOJPAImpl<WorkFlowEntity, Long> {
 
   private List<String> getMembersShipGroup(List<String> memberships) {
     return memberships.stream()
-                             .map(s -> (!s.startsWith("manager:/") && !s.startsWith("member:/")) ? s : s.replace("manager:","").replace("member:","") )
+                             .map(s -> (!s.startsWith("manager:/") && !s.startsWith("member:/") && !s.startsWith("*:/"))
+                                     ? s : s.replace("manager:","").replace("member:","").replace("*:",""))
                              .collect(Collectors.toList());
   }
 

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/WorkFlowCardItem.vue
@@ -19,7 +19,6 @@
         <template #activator="{ on, attrs }">
           <v-btn
             :class="isMobile ? 'three-dots mr-n2 mt-3' : 'three-dots mt-1'"
-            dark
             icon
             v-bind="attrs"
             v-on="!isMobileMenu && on"


### PR DESCRIPTION
Before this change, when UserA is a member in SpaceA and isn't member in spaceB and Admin creates ProcessX with spaceA as space manager and SpaceB as space requester then UserA opens the process app and clicks on I manage filter, filter I manage isn't displayed for userA . To resolve this problem, add a condition in the buildWorkflowQuery of the WorkFlowDAO Class if the filter is I manage I filter only by managers otherwise I can filter by managers and participators. After this change, all processes where I'm a member of their managing space should be displayed in I manage filter.

(cherry picked from commit d522f6daf5ecbf6d5b03c6e69aa56fcdb6203aa7)