### PR TITLE
fix: bad display in my request drawer in process app- EXO-77294.

### DIFF
--- a/processes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/processes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -9,6 +9,7 @@
         <portlet-name>Processes</portlet-name>
         <skin-name>Enterprise</skin-name>
         <css-path>/skin/css/processes.css</css-path>
+        <additional-module>taskCommentsDrawer</additional-module>
     </portlet-skin>
 
     <portlet>


### PR DESCRIPTION
Before this change, when create a process request and open drawer of the request, bad display of comment component. To fix this problem, add the import of the comment component css file. After this change, comment component displays correctly.