### PR TITLE
fix: Create request missing the ckeditor on text area - EXO-77485

### DIFF
--- a/processes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/processes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -23,6 +23,10 @@
                 <module>taskCommentsDrawer</module>
             </depends>
             <depends>
+                <module>commons-editor</module>
+                <as>editor</as>
+            </depends>
+            <depends>
                 <module>commonVueComponents</module>
             </depends>
             <depends>


### PR DESCRIPTION
Before this change, when create request on process and fill details of request, the text area is missing the text formatting tools. To fix this problem, add a depends commons-editor in gatein-resources. After this change, the request details include the text formatting tool.

(cherry picked from commit 52af7b14e358d7d99bcb95f7626f37a8319b1a49)