### PR TITLE
fix: Fix XMLValidator error with gatein-resources.xml at server startup - EXO-81271

### DIFF
--- a/processes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
+++ b/processes-webapp/src/main/webapp/WEB-INF/gatein-resources.xml
@@ -1,8 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" ?>
-<gatein-resources
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_resources_1_4 http://www.exoplatform.org/xml/ns/gatein_resources_1_4"
-        xmlns="http://www.exoplatform.org/xml/ns/gatein_resources_1_4">
+<gatein-resources xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.exoplatform.org/xml/ns/gatein_resources_1_5 http://www.exoplatform.org/xml/ns/gatein_resources_1_5" xmlns="http://www.exoplatform.org/xml/ns/gatein_resources_1_5">
 
     <portlet-skin>
         <application-name>processes</application-name>


### PR DESCRIPTION
Prior to this change starting a fresh 7.1.x server, we have an error related to the validation of processes addon gatein-resources.xml due to the gatein_resources xsd 1.4 version

ERROR | Error in document file:/E:/eXo/Binairies/platform-7.1.x-experience-SNAPSHOT/webapps/processes/WEB-INF/gatein-resources.xml  at (12,28) :cvc-complex-type.2.4.a: Invalid content was found starting with element '{"http://www.exoplatform.org/xml/ns/gatein_resources_1_4":additional-module}'. One of '{"http://www.exoplatform.org/xml/ns/gatein_resources_1_4":overwrite, "http://www.exoplatform.org/xml/ns/gatein_resources_1_4":css-priority}' is expected. [o.exoplatform.commons.xml.XMLValidator] After this commit, in order to avoid this error we will change the version to 1.5