### PR TITLE
fix: when adding a pdf during process edition, the content is never saved - EXO-81221

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImpl.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImpl.java
@@ -209,14 +209,16 @@ public class ProcessesAttachmentServiceImpl implements ProcessesAttachmentServic
         String destPath = destNode.getPath().concat("/").concat(attachmentNode.getName());
         if (!copy && !attachment.isEXoDrive()) {
           Node sourceEntityIdNode = attachmentNode.getParent();
-          session.move(attachmentNode.getPath(), destPath);
-          attachmentNode = (Node) session.getItem(destPath);
-          attachmentNode.addMixin(NodetypeConstant.EXO_HIDDENABLE);
+          session.save();
+          Workspace workspace = session.getWorkspace();
+          workspace.move(attachmentNode.getPath(), destPath);
+          Node copyNode = (Node) session.getItem(destPath);
+          copyNode.addMixin(NodetypeConstant.EXO_HIDDENABLE);
           if (attachments.size() - 1 == index && sourceEntityIdNode != null
                   && sourceEntityIdNode.getPrimaryNodeType().isNodeType(NodetypeConstant.NT_FOLDER)) {
             sourceEntityIdNode.remove();
           }
-          session.save();
+          copyNode.save();
         } else {
           session.save();
           Workspace workspace = session.getWorkspace();

--- a/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImplTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImplTest.java
@@ -142,8 +142,10 @@ public class ProcessesAttachmentServiceImplTest {
     List<Attachment> attachmentList = new ArrayList<>();
     Attachment attachment = new Attachment();
     attachment.setId("1");
+    Workspace workspace = mock(Workspace.class);
     Session session = mock(Session.class);
     Node node = mock(Node.class);
+    when(session.getWorkspace()).thenReturn(workspace);
     ExtendedNode extendedNode = mock(ExtendedNode.class);
     ProjectDto projectDto = new ProjectDto();
     projectDto.setId(1L);
@@ -189,7 +191,7 @@ public class ProcessesAttachmentServiceImplTest {
     when(extendedNode.getPath()).thenReturn("destPath");
     when(node.getParent()).thenReturn(node);
     processesAttachmentService.moveAttachmentsToEntity(1L, 1L, "workflow", 1L, "workdraft", 1L);
-    verify(session, times(1)).move("srcPath", "destPath/test");
+    verify(workspace, times(1)).move("srcPath", "destPath/test");
 
   }
 


### PR DESCRIPTION
Before this fix, when you create a pdf form inside a process during process edition (not process creation), The content of the pdf is never saved.
This is because the "move" action is not correctly done with the session, the jcr:content node have still path in the old location Using workplace.move ensure to move and save all the node and subtree