### PR TITLE
fix: edit Process : open pdf in edit mode not possible - EXO-81254

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/AddWorkFlowDrawer.vue
@@ -286,6 +286,7 @@
             :workflow-parent-space="workflowParentSpace"
             :allow-doc-form-creation="true"
             :edit-mode="editMode"
+            :edit-workflow="true"
             :entity-id="workflow.id"
             entity-type="workflow" />
           <v-btn

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
@@ -131,7 +131,8 @@ export default {
         attachments: JSON.parse(JSON.stringify(this.attachments)),
         spaceId: this.workflowParentSpace && this.workflowParentSpace.id,
         attachToEntity: this.editMode,
-        openAttachmentsInEditor: true
+        openAttachmentsInEditor: true,
+        canFillAttachments: !this.editWorkflow
       };
     },
     attachmentsLength() {
@@ -157,6 +158,8 @@ export default {
       this.$root.$emit('attachments-updated',this.attachments);
     });
     this.$root.$on('add-new-created-form-document', (doc) => {
+      doc.acl.canEdit = true;
+      doc.acl.canView = true;
       this.attachments.push(doc);
       this.subscribeDocument(doc.id);
       this.$root.$emit('attachments-updated', this.attachments);

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/attachments-integration/ProcessesAttachments.vue
@@ -85,6 +85,10 @@ export default {
       type: Boolean,
       default: false,
     },
+    editWorkflow: {
+      type: Boolean,
+      default: false,
+    },
     entityType: {
       type: String,
       default: null
@@ -189,7 +193,7 @@ export default {
     },
     isFileFillable(attachment) {
       const type = attachment && attachment.mimetype || '';
-      return type === 'application/pdf';
+      return !this.editWorkflow && type === 'application/pdf';
     },
     refreshSupportedDocumentExtensions () {
       this.supportedDocuments = extensionRegistry.loadExtensions('documents', 'supported-document-types');


### PR DESCRIPTION
Prior to this commit, pdf forms cannot be edited when editing a workflow
This change resolve this by opening the form in edit mode when editing the workflow.