### PR TITLE
fix: Selected group in who can make a request isn't maintained after save - EXO-83200 (#464)

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/Utils/EntityMapper.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/Utils/EntityMapper.java
@@ -78,7 +78,7 @@ public class EntityMapper {
         identityEntities.add(new CreatorIdentityEntity(identityEntity));
       } else {
         try {
-          Group group = manager.contains("/platform/") ? groupHandler.findGroupById(manager) : groupHandler.findGroupById("/platform/" + manager);
+          Group group = groupHandler.findGroupById(manager);
           ProfileEntity profile = new ProfileEntity(null, group.getLabel());
           IdentityEntity identityEntity = new IdentityEntity("group:" + group.getGroupName(), group.getId(), "group", profile);
           identityEntities.add(new CreatorIdentityEntity(identityEntity));


### PR DESCRIPTION
the selected group in who can make a request isn't maintained after save

(cherry picked from commit b7c66346ec1c7a7ba1bcf1c369fa86953b50acda) (cherry picked from commit 4398179c225359edb934984ad4705684f371348b)