### PR TITLE
fix: handle both /process and /processes paths when opening create request via URL - EXO-85656

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -355,8 +355,11 @@ export default {
       }
       if (path.endsWith('/createRequest')) {
         this.tab = 0;
-        const workflowId = path.split('processes/')[1].split(/\D/)[0];
-        this.openCreateWork(workflowId);
+        const match = path.match(/\/(\d+)\/createRequest$/);
+        const workflowId = match ? match[1] : null;
+        if (workflowId) {
+          this.openCreateWork(workflowId);
+        }
       }
       if (path.includes('/myRequests/requestDetails') && path.endsWith('/comments')) {
         this.tab = 1;


### PR DESCRIPTION
Prior to this change, only` /processes/{id}/createRequest `was handled, which caused the request drawer not to open and prevented create/edit/delete actions when using URLs with different prefixes.

This PR fixes the issue by extracting the workflow ID based solely on the number immediately preceding `/createRequest`, making it agnostic of the preceding path.