### PR TITLE
fix: Fix any user request creation on any process using its url - EXO-85598

### DIFF
--- a/processes-api/src/main/java/org/exoplatform/processes/service/ProcessesService.java
+++ b/processes-api/src/main/java/org/exoplatform/processes/service/ProcessesService.java
@@ -50,7 +50,7 @@ public interface ProcessesService {
   int countWorkFlows(ProcessesFilter filter,
                      long userIdentityId) throws IllegalAccessException;
 
-  WorkFlow getWorkFlow(long id) throws IllegalAccessException;
+  WorkFlow getWorkFlow(long id, Long userIdentityId) throws IllegalAccessException;
 
   WorkFlow createWorkFlow(WorkFlow workFlow, long userId) throws IllegalAccessException;
 

--- a/processes-api/src/main/java/org/exoplatform/processes/storage/ProcessesStorage.java
+++ b/processes-api/src/main/java/org/exoplatform/processes/storage/ProcessesStorage.java
@@ -60,7 +60,7 @@ public interface ProcessesStorage {
    */
   List<WorkFlow> findDisabledWorkFlows(int offset, int limit);
 
-  WorkFlow getWorkFlowById(long id);
+  WorkFlow getWorkFlowById(long id, Long userIdentityId);
 
   WorkFlow getWorkFlowByProjectId(long projectId);
 
@@ -174,9 +174,10 @@ public interface ProcessesStorage {
   List<WorkStatus> getAvailableWorkStatuses();
 
   /**
-   * Retrieves list fo filtered workflows
+   * Retrieves list of filtered workflows
    * 
    * @param processesFilter processes filter
+   * @param userIdentityId {@link Identity} technical identifier of the user
    * @param offset Offset of result list
    * @param limit limit of result list
    * @return {@link List} of {@link WorkFlow}

--- a/processes-services/src/main/java/org/exoplatform/processes/rest/ProcessesRest.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/rest/ProcessesRest.java
@@ -762,7 +762,7 @@ public class ProcessesRest implements ResourceContainer {
       if (workflowId == null) {
         return Response.status(Response.Status.BAD_REQUEST).build();
       }
-      WorkFlow workFlow = processesService.getWorkFlow(workflowId);
+      WorkFlow workFlow = processesService.getWorkFlow(workflowId, currentIdentityId);
       if (workFlow == null) {
         return Response.status(Response.Status.NOT_FOUND).build();
       }
@@ -849,7 +849,7 @@ public class ProcessesRest implements ResourceContainer {
       return Response.status(Response.Status.BAD_REQUEST).entity("workflow id is mandatory").build();
     }
     try {
-      WorkFlow workFlow = processesService.getWorkFlow(workflowId);
+      WorkFlow workFlow = processesService.getWorkFlow(workflowId, null);
       if (workFlow == null) {
         return Response.status(Response.Status.NOT_FOUND).entity("workflow not found").build();
       }

--- a/processes-services/src/main/java/org/exoplatform/processes/rest/util/EntityBuilder.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/rest/util/EntityBuilder.java
@@ -179,7 +179,7 @@ public class EntityBuilder {
     work.setAttachments(workEntity.getAttachments());
     if (workEntity.getWorkFlow() != null) {
       try {
-        WorkFlow workFlow = processesService.getWorkFlow(workEntity.getWorkFlow().getId());
+        WorkFlow workFlow = processesService.getWorkFlow(workEntity.getWorkFlow().getId(), null);
         if (workFlow != null) {
           work.setProjectId(workFlow.getProjectId());
         }

--- a/processes-services/src/main/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImpl.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImpl.java
@@ -306,7 +306,7 @@ public class ProcessesAttachmentServiceImpl implements ProcessesAttachmentServic
     Attachment attachment = attachmentService.createNewDocument(identity, title, path, pathDrive, templateName);
     if (entityId != null && entityType != null && Objects.equals(entityType, WORKFLOW_ENTITY_TYPE)) {
       ProcessesService processesService = CommonsUtils.getService(ProcessesService.class);
-      WorkFlow workFlow = processesService.getWorkFlow(entityId);
+      WorkFlow workFlow = processesService.getWorkFlow(entityId, null);
       linkAttachmentsToEntity(new Attachment[] { attachment },
                               userIdentityId,
                               entityId,

--- a/processes-services/src/main/java/org/exoplatform/processes/service/ProcessesServiceImpl.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/service/ProcessesServiceImpl.java
@@ -23,12 +23,8 @@ import org.exoplatform.commons.exception.ObjectNotFoundException;
 import org.exoplatform.commons.file.services.FileStorageException;
 import org.exoplatform.processes.model.*;
 import org.exoplatform.processes.storage.ProcessesStorage;
-import org.exoplatform.services.log.ExoLogger;
-import org.exoplatform.services.log.Log;
 
 public class ProcessesServiceImpl implements ProcessesService {
-
-  private static final Log       LOG = ExoLogger.getLogger(ProcessesServiceImpl.class);
 
   private final ProcessesStorage processesStorage;
 
@@ -50,8 +46,8 @@ public class ProcessesServiceImpl implements ProcessesService {
   }
 
   @Override
-  public WorkFlow getWorkFlow(long id) throws IllegalAccessException {
-    return processesStorage.getWorkFlowById(id);
+  public WorkFlow getWorkFlow(long id, Long userIdentityId) throws IllegalAccessException {
+    return processesStorage.getWorkFlowById(id, userIdentityId);
   }
 
   @Override
@@ -79,7 +75,7 @@ public class ProcessesServiceImpl implements ProcessesService {
     }
     // TODO check permissions to update types
 
-    WorkFlow oldWorkFlow = processesStorage.getWorkFlowById(workFlow.getId());
+    WorkFlow oldWorkFlow = processesStorage.getWorkFlowById(workFlow.getId(), null);
     if (oldWorkFlow == null) {
       throw new ObjectNotFoundException("oldWorkFlow is not exist");
     }

--- a/processes-services/src/main/java/org/exoplatform/processes/storage/ProcessesStorageImpl.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/storage/ProcessesStorageImpl.java
@@ -4,7 +4,17 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.text.SimpleDateFormat;
-import java.util.*;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Date;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.StringUtils;
@@ -20,7 +30,14 @@ import org.exoplatform.processes.dao.WorkDraftDAO;
 import org.exoplatform.processes.dao.WorkFlowDAO;
 import org.exoplatform.processes.entity.WorkEntity;
 import org.exoplatform.processes.entity.WorkFlowEntity;
-import org.exoplatform.processes.model.*;
+import org.exoplatform.processes.model.CreatorIdentityEntity;
+import org.exoplatform.processes.model.IdentityEntity;
+import org.exoplatform.processes.model.IllustrativeAttachment;
+import org.exoplatform.processes.model.ProcessesFilter;
+import org.exoplatform.processes.model.Work;
+import org.exoplatform.processes.model.WorkFilter;
+import org.exoplatform.processes.model.WorkFlow;
+import org.exoplatform.processes.model.WorkStatus;
 import org.exoplatform.processes.service.ProcessesAttachmentService;
 import org.exoplatform.services.listener.ListenerService;
 import org.exoplatform.services.log.ExoLogger;
@@ -120,8 +137,10 @@ public class ProcessesStorageImpl implements ProcessesStorage {
   }
 
   @Override
-  public WorkFlow getWorkFlowById(long id) {
-    return EntityMapper.fromEntity(workFlowDAO.find(id), null);
+  public WorkFlow getWorkFlowById(long id, Long userIdentityId) {
+    Map.Entry<String, List<String>> userMemberships = getUserMemberships(userIdentityId);
+    List<String> memberships = userMemberships.getValue();
+    return EntityMapper.fromEntity(workFlowDAO.find(id), memberships);
   }
 
   @Override
@@ -191,21 +210,6 @@ public class ProcessesStorageImpl implements ProcessesStorage {
                                                        WORKFLOW_ENTITY_TYPE,
                                                        workFlowEntity.getProjectId());
     return EntityMapper.fromEntity(workFlowEntity, illustrativeAttachment, null);
-  }
-
-  Set<String> getManagers(List<CreatorIdentityEntity> requestsCreators) {
-    List<String> managers = new ArrayList();
-    for (CreatorIdentityEntity id : requestsCreators) {
-      if (id.getIdentity().getProviderId().equals("space")) {
-        Space space = spaceService.getSpaceByPrettyName(id.getIdentity().getRemoteId());
-        if (space != null) {
-          managers.add(space.getGroupId());
-        }
-      } else {
-        managers.add(id.getIdentity().getRemoteId());
-      }
-    }
-    return new HashSet<>(managers);
   }
 
   /**
@@ -573,36 +577,10 @@ public class ProcessesStorageImpl implements ProcessesStorage {
    */
   @Override
   public List<WorkFlow> findWorkFlows(ProcessesFilter processesFilter, long userIdentityId, int offset, int limit) {
-    String userName = "";
-    List<String> memberships = new ArrayList<>();
-    boolean isMemberProcessesGroup = false;
-    if (userIdentityId > 0) {
-      Identity identity = identityManager.getIdentity(String.valueOf(userIdentityId));
-      if (identity != null) {
-        userName = identity.getRemoteId();
-        memberships.add(userName);
-        try {
-          Collection<Membership> ms = organizationService.getMembershipHandler().findMembershipsByUser(userName);
-          if (ms != null) {
-            for (Membership membership : ms) {
-              if (membership.getGroupId().equals(PROCESSES_GROUP)) {
-                isMemberProcessesGroup = true;
-              }
-              String membership_ = membership.getMembershipType() + ":" + membership.getGroupId();
-              memberships.add(membership_);
-            }
-          }
-        } catch (Exception e) {
-          LOG.error("Error while getting the user memberships", e);
-        }
-      }
-    }
-    List<WorkFlowEntity> workFlowEntities;
-    if (isMemberProcessesGroup) {
-      workFlowEntities = workFlowDAO.findWorkFlows(processesFilter, null, offset, limit);
-    } else {
-      workFlowEntities = workFlowDAO.findWorkFlows(processesFilter, memberships, offset, limit);
-    }
+    Map.Entry<String, List<String>> userMemberships = getUserMemberships(userIdentityId);
+    String userName = userMemberships.getKey();
+    List<String> memberships = userMemberships.getValue();
+    List<WorkFlowEntity> workFlowEntities = workFlowDAO.findWorkFlows(processesFilter, memberships, offset, limit);
     List<WorkFlow> workFlows = new ArrayList<>();
     List<String> finalMemberships = memberships;
     workFlowEntities.forEach(workflowEntity -> {
@@ -620,14 +598,8 @@ public class ProcessesStorageImpl implements ProcessesStorage {
     String finalUserName = userName;
     workFlows.forEach(workflow -> {
       if (workflow != null) {
-        boolean canShowPending = false;
-        try {
-          Space space = ProcessesUtils.getProjectParentSpace(workflow.getProjectId());
-          canShowPending = canShowPending(finalUserName, space);
-        } catch (Exception e) {
-          LOG.error("Error while getting workflow can Show Pending", e);
-        }
-        workflow.setCanShowPending(canShowPending);
+        Space space = ProcessesUtils.getProjectParentSpace(workflow.getProjectId());
+        workflow.setCanShowPending(space != null && (spaceService.isSuperManager(finalUserName) || spaceService.isMember(space, finalUserName)));
       }
     });
     return workFlows;
@@ -641,11 +613,47 @@ public class ProcessesStorageImpl implements ProcessesStorage {
     return workFlowDAO.countWorkFlows(processesFilter);
   }
 
-  private boolean canShowPending(String authenticatedUser, Space space) {
-    if (space != null) {
-      return (spaceService.isSuperManager(authenticatedUser) || spaceService.isMember(space, authenticatedUser));
-    } else
-      return false;
+  private Map.Entry<String, List<String>> getUserMemberships(Long userIdentityId) {
+    if (userIdentityId == null || userIdentityId <= 0) {
+      return Map.entry("", new ArrayList<>());
+    }
+    Identity identity = identityManager.getIdentity(String.valueOf(userIdentityId));
+    if (identity == null) {
+      return Map.entry("", new ArrayList<>());
+    }
+    String userName = identity.getRemoteId();
+    List<String> memberships = new ArrayList<>();
+    memberships.add(userName);
+    try {
+      Collection<Membership> ms = organizationService.getMembershipHandler().findMembershipsByUser(userName);
+      if (ms != null) {
+        for (Membership membership : ms) {
+          if (membership.getGroupId().equals(PROCESSES_GROUP)) {
+            return new AbstractMap.SimpleEntry<>(userName, null);
+          }
+          String membership_ = membership.getMembershipType() + ":" + membership.getGroupId();
+          memberships.add(membership_);
+        }
+      }
+    } catch (Exception e) {
+      LOG.error("Error while getting the user memberships", e);
+    }
+    return Map.entry(userName, memberships);
   }
-
+  
+  private Set<String> getManagers(List<CreatorIdentityEntity> requestsCreators) {
+    Set<String> managers = new HashSet<>();
+    for (CreatorIdentityEntity creatorIdentityEntity : requestsCreators) {
+      IdentityEntity creatorIdentity = creatorIdentityEntity.getIdentity();
+      if ("space".equals(creatorIdentity.getProviderId())) {
+        Space space = spaceService.getSpaceByPrettyName(creatorIdentity.getRemoteId());
+        if (space != null) {
+          managers.add(space.getGroupId());
+        }
+      } else {
+        managers.add(creatorIdentity.getRemoteId());
+      }
+    }
+    return managers;
+  }
 }

--- a/processes-services/src/test/java/org/exoplatform/processes/rest/ProcessesRestTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/rest/ProcessesRestTest.java
@@ -546,14 +546,14 @@ public class ProcessesRestTest {
     REST_UTILS.when(() -> RestUtils.getCurrentUserIdentityId(identityManager)).thenReturn(1L);
     Response response1 = processesRest.getWorkFlowById(null, "");
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response1.getStatus());
-    when(processesService.getWorkFlow(1L)).thenReturn(null);
+    when(processesService.getWorkFlow(anyLong(), anyLong())).thenReturn(null);
     Response response2 = processesRest.getWorkFlowById(1L, "");
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response2.getStatus());
-    when(processesService.getWorkFlow(1L)).thenReturn(workFlow);
+    when(processesService.getWorkFlow(anyLong(), anyLong())).thenReturn(workFlow);
     ENTITY_BUILDER.when(() -> EntityBuilder.toEntity(workFlow, "")).thenReturn(workFlowEntity);
     Response response3 = processesRest.getWorkFlowById(1L, "");
     assertEquals(Response.Status.OK.getStatusCode(), response3.getStatus());
-    doThrow(new RuntimeException()).when(processesService).getWorkFlow(1L);
+    doThrow(new RuntimeException()).when(processesService).getWorkFlow(anyLong(), anyLong());
     Response response4 = processesRest.getWorkFlowById(1L, "");
     assertEquals(Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), response4.getStatus());
   }
@@ -654,10 +654,10 @@ public class ProcessesRestTest {
     workFlow.setIllustrativeAttachment(illustrativeAttachment);
     Response response = processesRest.getImageIllustration(request, null, 0);
     assertEquals(Response.Status.BAD_REQUEST.getStatusCode(), response.getStatus());
-    when(processesService.getWorkFlow(1L)).thenReturn(null);
+    when(processesService.getWorkFlow(1L, null)).thenReturn(null);
     Response response1 = processesRest.getImageIllustration(request, 1L, 0);
     assertEquals(Response.Status.NOT_FOUND.getStatusCode(), response1.getStatus());
-    when(processesService.getWorkFlow(1L)).thenReturn(workFlow);
+    when(processesService.getWorkFlow(1L, null)).thenReturn(workFlow);
     when(processesService.getIllustrationImageById(1L)).thenReturn(illustrativeAttachment);
     when(request.evaluatePreconditions(any(EntityTag.class))).thenReturn(null);
     Response response2 = processesRest.getImageIllustration(request, 1L, 0);

--- a/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImplTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesAttachmentServiceImplTest.java
@@ -284,7 +284,7 @@ public class ProcessesAttachmentServiceImplTest {
     workFlow.setProjectId(1L);
     ProcessesService processesService = mock(ProcessesService.class);
     COMMONS_UTILS.when(() -> CommonsUtils.getService(ProcessesService.class)).thenReturn(processesService);
-    when(processesService.getWorkFlow(1L)).thenReturn(workFlow);
+    when(processesService.getWorkFlow(1L, null)).thenReturn(workFlow);
     Attachment attachment = mock(Attachment.class);
     when(attachmentService.createNewDocument(any(), any(), any(), any(), any())).thenReturn(attachment);
     copyAttachmentsToEntity();

--- a/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesServiceImplTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/service/ProcessesServiceImplTest.java
@@ -99,8 +99,8 @@ public class ProcessesServiceImplTest {
   @Test
   public void getWorkFlow() throws IllegalAccessException {
 
-    when(processesStorage.getWorkFlowById(1L)).thenReturn(enabledWorkFlow);
-    assertEquals(processesService.getWorkFlow(1L).getId(), 1L);
+    when(processesStorage.getWorkFlowById(1L, null)).thenReturn(enabledWorkFlow);
+    assertEquals(processesService.getWorkFlow(1L, null).getId(), 1L);
   }
 
   @Test
@@ -129,15 +129,15 @@ public class ProcessesServiceImplTest {
     verify(processesStorage, times(0)).getWorkById(1L);
 
     workFlow.setId(1L);
-    when(processesStorage.getWorkFlowById(workFlow.getId())).thenReturn(null);
+    when(processesStorage.getWorkFlowById(workFlow.getId(), null)).thenReturn(null);
     Throwable exception3 = assertThrows(ObjectNotFoundException.class, () -> this.processesService.updateWorkFlow(workFlow, 1l));
     assertEquals("oldWorkFlow is not exist", exception3.getMessage());
 
-    when(processesStorage.getWorkFlowById(workFlow.getId())).thenReturn(workFlow);
+    when(processesStorage.getWorkFlowById(workFlow.getId(), null)).thenReturn(workFlow);
     Throwable exception4 = assertThrows(IllegalArgumentException.class, () -> this.processesService.updateWorkFlow(workFlow, 1l));
     assertEquals("there are no changes to save", exception4.getMessage());
 
-    when(processesStorage.getWorkFlowById(workFlow.getId())).thenReturn(updatedWorkflow);
+    when(processesStorage.getWorkFlowById(workFlow.getId(), null)).thenReturn(updatedWorkflow);
     this.processesService.updateWorkFlow(workFlow, 1l);
     verify(processesStorage, times(1)).saveWorkFlow(workFlow, 1L);
   }

--- a/processes-services/src/test/java/org/exoplatform/processes/storage/ProcessesStorageImplTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/storage/ProcessesStorageImplTest.java
@@ -665,7 +665,7 @@ public class ProcessesStorageImplTest {
     when(workFlow.getIllustrativeAttachment()).thenReturn(illustrativeAttachment);
     this.processesStorage.saveWorkFlow(workFlow, 1L);
     when(organizationService.getMembershipHandler()).thenReturn(membershipHandler);
-    assertEquals(null, this.processesStorage.getWorkFlowById(1));
+    assertEquals(null, this.processesStorage.getWorkFlowById(1, null));
 
     Collection<Membership> memberships_ = new ArrayList();
     MembershipImpl membership;

--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -373,7 +373,9 @@ export default {
     },
     openCreateWork(workflowId) {
       this.$processesService.getWorkflowById(workflowId, '').then(workflow => {
-        this.$root.$emit('open-add-work-drawer', {object: workflow, mode: 'create_work'});
+        if (workflow.acl.canAddRequest) {
+          this.$root.$emit('open-add-work-drawer', {object: workflow, mode: 'create_work'});
+        }
       });
     },
     updateState(value) {


### PR DESCRIPTION

Prior to this change, any user can create a request on any process using its url even if he has not rights for that. This is caused by the lack of checking on user acl.canAddRequest when opening the add request drawer. After this commit, we ensure to add this check in order to allow only allowed users to create a request.