### PR TITLE
fix: handle both /process and /processes paths when opening create request via URL - EXO-85656 (#472)

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -355,8 +355,11 @@ export default {
       }
       if (path.endsWith('/createRequest')) {
         this.tab = 0;
-        const workflowId = path.split('processes/')[1].split(/\D/)[0];
-        this.openCreateWork(workflowId);
+        const match = path.match(/\/(\d+)\/createRequest$/);
+        const workflowId = match ? match[1] : null;
+        if (workflowId) {
+          this.openCreateWork(workflowId);
+        }
       }
       if (path.includes('/myRequests/requestDetails') && path.endsWith('/comments')) {
         this.tab = 1;


### PR DESCRIPTION
Prior to this change, only `/processes/{id}/createRequest` was handled,
 which caused the request drawer not to open and prevented create/edit/delete actions when using `/process/{id}/createRequest`.

This PR fixes the issue by supporting both path formats when extracting the workflow ID.

(cherry picked from commit dca23fcfa388429ff401535f3ec35a7093b921fe)