### PR TITLE
fix: Fix the search in my requests while using the completed filter - EXO-86977

### DIFF
--- a/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
+++ b/processes-webapp/src/main/webapp/vue-app/processes/components/Processes.vue
@@ -472,6 +472,9 @@ export default {
       const filter = {
         completed: true
       };
+      if (this.query) {
+        filter.query = this.query;
+      }      
       this.$processesService.getWorks(filter, 0, 0, expand).then(works => {
         works.forEach(work => {
           work.status = 'completed';


### PR DESCRIPTION
Prior to this change, the typed term in the search box in myRequests interface while using the archived filter was ignored.
To fix it, query property is added to filter object.