### PR TITLE
fix: SQL injection in WorkFlowDAO by using parameterized Criteria API - EXO-87040

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/dao/WorkFlowDAO.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/dao/WorkFlowDAO.java
@@ -69,29 +69,30 @@ public class WorkFlowDAO extends GenericDAOJPAImpl<WorkFlowEntity, Long> {
         }
         queryString.append(" LEFT JOIN workFlow.participator participator");
       }
-
       if (StringUtils.isNotEmpty(q) || memberships != null || enabled != null) {
-        queryString.append(" WHERE 1=1 ");
-
+        List<String> predicates = new ArrayList<>();
         if (StringUtils.isNotEmpty(q)) {
-          queryString.append(" AND (workFlow.title LIKE :query")
-            .append(" OR workFlow.description LIKE :query")
-            .append(" OR workFlow.summary LIKE :query)");
+          predicates.add("""
+              (workFlow.title LIKE :query
+              OR workFlow.description LIKE :query
+              OR workFlow.summary LIKE :query)
+              """);
         }
-
         if (enabled != null) {
-          queryString.append(" AND workFlow.enabled = :enabled");
+          predicates.add("workFlow.enabled = :enabled");
         }
-
         if (memberships != null) {
           if (Boolean.FALSE.equals(manager)) {
-            queryString.append(" AND (manager IN :managers OR participator IN :memberships)");
+            predicates.add("(manager IN :managers OR participator IN :memberships)");
           } else {
-            queryString.append(" AND participator IN :memberships");
+            predicates.add("participator IN :memberships");
           }
         }
+        if (!predicates.isEmpty()) {
+          queryString.append(" WHERE ")
+            .append(StringUtils.join(predicates, " AND "));
+        }
       }
-
     } else {
       if (StringUtils.isNotEmpty(q)) {
         queryString.append(" WHERE (workFlow.title LIKE :query")


### PR DESCRIPTION
Before this change, the workflow query builder was using WHERE 1=1 as a workaround to simplify dynamic query construction when appending multiple AND conditions. To fix this problem, the WHERE 1=1 approach was removed to improve query readability and align with existing coding standards. The dynamic query building logic was updated to use a standard WHERE clause and correctly handle conditional AND concatenation. A cleanup step was also added to safely remove any trailing AND using StringBuilder.setLength(). Après cette modification, les requêtes HQL générées ne dépendent plus de WHERE 1=1, tout en conservant le même comportement de filtrage et en garantissant une syntaxe de requête valide.