### PR TITLE
fix: Avoid Adding JPQL Parameter when not present in Query - EXO-87635

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/dao/WorkFlowDAO.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/dao/WorkFlowDAO.java
@@ -117,12 +117,14 @@ public class WorkFlowDAO extends GenericDAOJPAImpl<WorkFlowEntity, Long> {
 
     if (memberships != null) {
       query.setParameter("memberships", memberships);
-      query.setParameter("managers", getMembersShipGroup(memberships));
+      if (Boolean.FALSE.equals(processesFilter.getManager())) {
+        query.setParameter("managers", getMembershipGroups(memberships));
+      }
     }
     return query;
   }
 
-  private List<String> getMembersShipGroup(List<String> memberships) {
+  private List<String> getMembershipGroups(List<String> memberships) {
     return memberships.stream()
                              .map(s -> (!s.startsWith("manager:/") && !s.startsWith("member:/") && !s.startsWith("*:/"))
                                      ? s : s.replace("manager:","").replace("member:","").replace("*:",""))


### PR DESCRIPTION
Prior to this change, the JPQL used business logic isn't the same as Query Parameters building. This change ensures to not add a non-existing parameter in built JPA Query.