### PR TITLE
feat: migrate statistic fields to typed collection API - EXO-87596

### DIFF
--- a/processes-services/src/main/java/org/exoplatform/processes/listener/ProcessAnalyticsListener.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/listener/ProcessAnalyticsListener.java
@@ -40,8 +40,8 @@ public class ProcessAnalyticsListener extends Listener<Long, WorkFlow> {
     statisticData.setSubModule("process");
     statisticData.setOperation(operation);
     statisticData.setUserId(userId);
-    statisticData.addParameter("processID", workFlow.getId());
-    statisticData.addParameter("processName", workFlow.getTitle());
+    statisticData.addKeyword("processID", workFlow.getId());
+    statisticData.addKeyword("processName", workFlow.getTitle());
     AnalyticsUtils.addStatisticData(statisticData);
   }
 }

--- a/processes-services/src/main/java/org/exoplatform/processes/listener/RequestAnalyticsListener.java
+++ b/processes-services/src/main/java/org/exoplatform/processes/listener/RequestAnalyticsListener.java
@@ -47,10 +47,10 @@ public class RequestAnalyticsListener extends Listener<Work, ProjectDto> {
     statisticData.setSubModule("request");
     statisticData.setOperation(operation);
     statisticData.setUserId(userId);
-    statisticData.addParameter("processID", workFlow.getId());
-    statisticData.addParameter("processName", workFlow.getTitle());
-    statisticData.addParameter("requestID", work.getId());
-    statisticData.addParameter("requestName", work.getTitle());
+    statisticData.addKeyword("processID", workFlow.getId());
+    statisticData.addKeyword("processName", workFlow.getTitle());
+    statisticData.addKeyword("requestID", work.getId());
+    statisticData.addKeyword("requestName", work.getTitle());
     AnalyticsUtils.addStatisticData(statisticData);
   }
 }


### PR DESCRIPTION
Replace deprecated StatisticData#addParameter usages with explicit typed APIs across product modules.

Use addKeyword/addKeywords for identifiers and labels, addLong for numeric aggregation fields, and typed collection variants where needed. This makes the intended Elasticsearch mapping explicit at producer level and avoids accidental field type changes or unnecessary *_alt mapping creation.