### PR TITLE
test: fix processes-services coverage gate failure on feature/ai-contribution - EXO-88467

### DIFF
--- a/processes-services/src/test/java/org/exoplatform/processes/mcp/ProcessesMcpToolTest.java
+++ b/processes-services/src/test/java/org/exoplatform/processes/mcp/ProcessesMcpToolTest.java
@@ -19,25 +19,40 @@ package org.exoplatform.processes.mcp;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
+import org.exoplatform.commons.exception.ObjectNotFoundException;
+import org.exoplatform.processes.mcp.model.PendingApprovalModel;
+import org.exoplatform.processes.mcp.model.RequestModel;
 import org.exoplatform.processes.model.ProcessesFilter;
+import org.exoplatform.processes.model.Work;
+import org.exoplatform.processes.model.WorkFilter;
+import org.exoplatform.processes.model.WorkFlow;
 import org.exoplatform.processes.service.ProcessesService;
 import org.exoplatform.services.security.ConversationState;
 import org.exoplatform.social.core.identity.model.Identity;
 import org.exoplatform.social.core.manager.IdentityManager;
+import org.exoplatform.task.dao.TaskQuery;
+import org.exoplatform.task.dto.ProjectDto;
+import org.exoplatform.task.dto.StatusDto;
+import org.exoplatform.task.dto.TaskDto;
 import org.exoplatform.task.service.TaskService;
 
 /**
@@ -108,6 +123,199 @@ public class ProcessesMcpToolTest {
     verify(processesService).getWorkFlows(captor.capture(), anyInt(), anyInt(), anyLong());
     assertNotNull("isProcessManager must be non-null (the service unboxes it into a boolean)",
                   captor.getValue().getIsProcessManager());
+  }
+
+  @Test
+  public void getMyRequestsReturnsMappedRequestsForCurrentUser() throws Exception {
+    Work work = new Work();
+    work.setId(10L);
+    work.setTitle("My request");
+    work.setStatus("Request");
+    when(processesService.getWorks(eq(1L), any(WorkFilter.class), anyInt(), anyInt())).thenReturn(Collections.singletonList(work));
+
+    List<RequestModel> requests = tool.getMyRequests("Request");
+
+    assertEquals(1, requests.size());
+    assertEquals(10L, requests.get(0).id());
+    assertEquals("My request", requests.get(0).title());
+
+    ArgumentCaptor<WorkFilter> captor = ArgumentCaptor.forClass(WorkFilter.class);
+    verify(processesService).getWorks(eq(1L), captor.capture(), anyInt(), anyInt());
+    assertEquals("Request", captor.getValue().getStatus());
+  }
+
+  @Test
+  public void getMyRequestsLeavesStatusUnsetWhenBlank() throws Exception {
+    when(processesService.getWorks(anyLong(), any(WorkFilter.class), anyInt(), anyInt())).thenReturn(Collections.emptyList());
+
+    tool.getMyRequests("  ");
+
+    ArgumentCaptor<WorkFilter> captor = ArgumentCaptor.forClass(WorkFilter.class);
+    verify(processesService).getWorks(anyLong(), captor.capture(), anyInt(), anyInt());
+    assertNull(captor.getValue().getStatus());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void getRequestDetailsRejectsNonPositiveId() throws Exception {
+    tool.getRequestDetails(0L);
+  }
+
+  @Test(expected = ObjectNotFoundException.class)
+  public void getRequestDetailsThrowsWhenRequestNotFound() throws Exception {
+    when(processesService.getWorkById(1L, 99L)).thenReturn(null);
+
+    tool.getRequestDetails(99L);
+  }
+
+  @Test
+  public void getRequestDetailsReturnsMappedRequest() throws Exception {
+    Work work = new Work();
+    work.setId(7L);
+    work.setTitle("Details request");
+    when(processesService.getWorkById(1L, 7L)).thenReturn(work);
+
+    RequestModel request = tool.getRequestDetails(7L);
+
+    assertEquals(7L, request.id());
+    assertEquals("Details request", request.title());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void submitWorkRequestRejectsNonPositiveProcessId() throws Exception {
+    tool.submitWorkRequest(0L, "title", "description");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void submitWorkRequestRejectsBlankTitle() throws Exception {
+    tool.submitWorkRequest(1L, "  ", "description");
+  }
+
+  @Test(expected = ObjectNotFoundException.class)
+  public void submitWorkRequestThrowsWhenProcessNotFound() throws Exception {
+    when(processesService.getWorkFlow(5L, 1L)).thenReturn(null);
+
+    tool.submitWorkRequest(5L, "title", "description");
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void submitWorkRequestRejectsDisabledProcess() throws Exception {
+    WorkFlow workFlow = new WorkFlow();
+    workFlow.setId(5L);
+    workFlow.setTitle("Disabled process");
+    workFlow.setEnabled(false);
+    when(processesService.getWorkFlow(5L, 1L)).thenReturn(workFlow);
+
+    tool.submitWorkRequest(5L, "title", "description");
+  }
+
+  @Test
+  public void submitWorkRequestCreatesWorkUnderProcessProject() throws Exception {
+    WorkFlow workFlow = new WorkFlow();
+    workFlow.setId(5L);
+    workFlow.setEnabled(true);
+    workFlow.setProjectId(42L);
+    when(processesService.getWorkFlow(5L, 1L)).thenReturn(workFlow);
+
+    Work created = new Work();
+    created.setId(11L);
+    created.setTitle("New request");
+    when(processesService.createWork(any(Work.class), eq(1L))).thenReturn(created);
+
+    RequestModel request = tool.submitWorkRequest(5L, "New request", null);
+
+    assertEquals(11L, request.id());
+    ArgumentCaptor<Work> captor = ArgumentCaptor.forClass(Work.class);
+    verify(processesService).createWork(captor.capture(), eq(1L));
+    assertEquals("New request", captor.getValue().getTitle());
+    assertEquals(42L, captor.getValue().getProjectId());
+    assertEquals("", captor.getValue().getDescription());
+  }
+
+  @Test(expected = IllegalArgumentException.class)
+  public void cancelWorkRequestRejectsNonPositiveId() throws Exception {
+    tool.cancelWorkRequest(0L);
+  }
+
+  @Test(expected = ObjectNotFoundException.class)
+  public void cancelWorkRequestThrowsWhenRequestNotFound() throws Exception {
+    when(processesService.getWorkById(1L, 99L)).thenReturn(null);
+
+    tool.cancelWorkRequest(99L);
+  }
+
+  @Test
+  public void cancelWorkRequestReturnsAsIsWhenAlreadyCanceled() throws Exception {
+    Work work = new Work();
+    work.setId(3L);
+    work.setStatus("Canceled");
+    work.setCompleted(true);
+    when(processesService.getWorkById(1L, 3L)).thenReturn(work);
+
+    tool.cancelWorkRequest(3L);
+
+    verify(processesService, never()).updateWork(any(Work.class), anyLong());
+  }
+
+  @Test
+  public void cancelWorkRequestCancelsPendingRequest() throws Exception {
+    Work work = new Work();
+    work.setId(3L);
+    work.setStatus("Request");
+    work.setCompleted(false);
+    when(processesService.getWorkById(1L, 3L)).thenReturn(work);
+    when(processesService.updateWork(any(Work.class), eq(1L))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    RequestModel result = tool.cancelWorkRequest(3L);
+
+    assertEquals("Canceled", result.status());
+    assertTrue(result.completed());
+    ArgumentCaptor<Work> captor = ArgumentCaptor.forClass(Work.class);
+    verify(processesService).updateWork(captor.capture(), eq(1L));
+    assertEquals("Canceled", captor.getValue().getStatus());
+    assertTrue(captor.getValue().isCompleted());
+  }
+
+  @Test
+  public void getPendingApprovalsReturnsEmptyWhenNoManagedProcess() throws Exception {
+    WorkFlow workFlow = new WorkFlow();
+    workFlow.setProjectId(5L);
+    workFlow.setCanShowPending(false);
+    when(processesService.getWorkFlows(any(ProcessesFilter.class), anyInt(), anyInt(), anyLong())).thenReturn(Collections.singletonList(workFlow));
+
+    List<PendingApprovalModel> pending = tool.getPendingApprovals();
+
+    assertTrue(pending.isEmpty());
+    verify(taskService, never()).findTasks(any(TaskQuery.class), anyInt(), anyInt());
+  }
+
+  @Test
+  public void getPendingApprovalsMapsTasksFromManagedProjects() throws Exception {
+    WorkFlow workFlow = new WorkFlow();
+    workFlow.setProjectId(5L);
+    workFlow.setTitle("Onboarding");
+    workFlow.setCanShowPending(true);
+    when(processesService.getWorkFlows(any(ProcessesFilter.class), anyInt(), anyInt(), anyLong())).thenReturn(Collections.singletonList(workFlow));
+
+    ProjectDto project = new ProjectDto();
+    project.setId(5L);
+    StatusDto status = new StatusDto();
+    status.setName("Request");
+    status.setProject(project);
+    TaskDto task = new TaskDto();
+    task.setId(21L);
+    task.setTitle("Pending task");
+    task.setStatus(status);
+    task.setCreatedBy("john");
+
+    when(taskService.findTasks(any(TaskQuery.class), anyInt(), anyInt())).thenReturn(Collections.singletonList(task))
+                                                                          .thenReturn(Collections.emptyList());
+
+    List<PendingApprovalModel> pending = tool.getPendingApprovals();
+
+    assertEquals(1, pending.size());
+    assertEquals(21L, pending.get(0).taskId());
+    assertEquals("Onboarding", pending.get(0).processTitle());
+    assertEquals(5L, pending.get(0).projectId());
   }
 
 }


### PR DESCRIPTION
## Summary
CI (`addon-processes-ai-contribution-fb-ci`) fails `processes-services` at the JaCoCo `-Pcoverage` gate:
```
[WARNING] Rule violated for bundle processes-services: instructions covered ratio is 0.55, but expected minimum is 0.58
```

`develop` already sits right at the edge (58.1% instruction coverage). `ProcessesMcpTool`, added by #486, landed with only 2 tests (`ProcessesMcpToolTest`), both narrowly guarding `listProcesses`/`getPendingApprovals` against a null-unbox NPE — the other methods (`getMyRequests`, `getRequestDetails`, `submitWorkRequest`, `cancelWorkRequest`, and the task-mapping half of `getPendingApprovals`) were untested, leaving the class at 20.7% coverage (111/536 instructions). That's enough to drag the whole bundle to 55%, under the gate.

## Fix
Added tests for the remaining methods in `ProcessesMcpToolTest`:
- `getMyRequests`: status passed through / left unset when blank
- `getRequestDetails`: invalid id, not-found, happy path
- `submitWorkRequest`: invalid id/title, process not found, disabled process, happy path (asserts the created `Work`'s project id/description)
- `cancelWorkRequest`: invalid id, not-found, idempotent no-op when already canceled, happy path (asserts status/completed + that `updateWork` isn't called on the no-op branch)
- `getPendingApprovals`: empty when no managed process (and `taskService` isn't called), task-to-`PendingApprovalModel` mapping (title/id/project) when a managed process has pending tasks

## Result
- `ProcessesMcpTool`: 20.7% → 92.9% instruction coverage
- `processes-services` bundle: 55% → 60.4%

## Test plan
- [x] `mvn -pl processes-services test -Dtest=ProcessesMcpToolTest` — 18/18 pass
- [x] `mvn -pl processes-services -Pcoverage clean install` — `BUILD SUCCESS`, no rule violation
- [x] `mvn -Pcoverage clean install` (full reactor) — `BUILD SUCCESS`