### PR TITLE
fix: process page permissions reset after server restart - EXO-87863

### DIFF
--- a/processes-webapp/src/main/webapp/WEB-INF/conf/processes/portal-configuration.xml
+++ b/processes-webapp/src/main/webapp/WEB-INF/conf/processes/portal-configuration.xml
@@ -49,7 +49,7 @@
                             <boolean>${exo.processes.portalConfig.metadata.override:true}</boolean>
                         </field>
                         <field name="importMode">
-                            <string>${exo.processes.portalConfig.metadata.importmode:merge}</string>
+                            <string>${exo.processes.portalConfig.metadata.importmode:insert}</string>
                         </field>
                     </object>
                 </object-param>


### PR DESCRIPTION
Before this change, when the server restarted, the processes portal navigation node was re-imported with importMode set to merge, which overwrote any custom permission configured by the admin on the processes page navigation. To fix this, the default importMode for the processes portal configuration was changed from merge to insert, so existing navigation nodes are no longer touched on subsequent startups. After this change, process page permissions set by the admin persists across server restarts.