### PR TITLE
feat: Declare the Process digest mail notifications category - EXO-89484 - eXIP7.3.0.22

### DIFF
--- a/processes-webapp/src/main/resources/locale/notification/ProcessesNotification_en.properties
+++ b/processes-webapp/src/main/resources/locale/notification/ProcessesNotification_en.properties
@@ -28,3 +28,6 @@ Notification.label.openRequest=Open Request
 Notification.label.SayHello=Hi
 Notification.label.footer=This email was sent to you as eXo Platform member.<a target="_blank" style="margin:30px 0 10px 0; color: #2f5e92;text-decoration: none;font-size:13px;font-family:HelveticaNeue,arial,tahoma,serif" href="{0}"> Click here</a> to change your notification settings.
 Notification.label.CompanyName=eXo Platform
+
+# Digest mail notifications: label of the category this addon owns
+digest.category.process=Process

--- a/processes-webapp/src/main/webapp/WEB-INF/conf/processes/notification-configuration.xml
+++ b/processes-webapp/src/main/webapp/WEB-INF/conf/processes/notification-configuration.xml
@@ -231,7 +231,6 @@
         <values-param>
           <name>pluginIds</name>
           <value>CreateRequestPlugin</value>
-          <value>CancelRequestPlugin</value>
           <value>RequestCommentPlugin</value>
         </values-param>
       </init-params>

--- a/processes-webapp/src/main/webapp/WEB-INF/conf/processes/notification-configuration.xml
+++ b/processes-webapp/src/main/webapp/WEB-INF/conf/processes/notification-configuration.xml
@@ -207,4 +207,34 @@
         </component-plugin>
     </external-component-plugins>
 
+  <!-- Digest mail notifications: the category this addon owns -->
+  <external-component-plugins>
+    <target-component>io.meeds.commons.digest.DigestCategoryRegistry</target-component>
+    <component-plugin>
+      <name>process</name>
+      <set-method>addCategoryProvider</set-method>
+      <type>io.meeds.commons.digest.plugin.DigestCategoryPlugin</type>
+      <description>The process notifications: requests and their follow up</description>
+      <init-params>
+        <value-param>
+          <name>id</name>
+          <value>process</value>
+        </value-param>
+        <value-param>
+          <name>labelKey</name>
+          <value>digest.category.process</value>
+        </value-param>
+        <value-param>
+          <name>order</name>
+          <value>60</value>
+        </value-param>
+        <values-param>
+          <name>pluginIds</name>
+          <value>CreateRequestPlugin</value>
+          <value>CancelRequestPlugin</value>
+          <value>RequestCommentPlugin</value>
+        </values-param>
+      </init-params>
+    </component-plugin>
+  </external-component-plugins>
 </configuration>


### PR DESCRIPTION
Part of eXIP 7.3.0.22 — Digest Mail Notifications. Task EXO-89484 (US03).

Contributes the **Process** category to the digest settings drawer. Depends on Meeds-io/commons#772, which brings the Kernel `DigestCategoryRegistry` this configuration targets — **merge that one first**.

Pure configuration, no Java:
- The category is declared as a `component-plugin` on the registry, next to the notification plugins it already declares, and covers the 3 process plugins (request created, canceled, commented).
- Its label is added to the resource bundle those plugins already use, where social's `DigestCategoryLabelResolver` reads it — translated server side, so the settings page has nothing to load.

The categories are declared in the Kernel rather than as Spring beans on purpose: each webapp has its own Spring context, and only the Kernel container is shared by all of them. This addon's category therefore reaches the digest whatever the addon is made of.

## AI contribution

Classified **N1** — human-driven, no auto-merge, author ≠ approver.
